### PR TITLE
feat: Add confirmation modal for script installation and server sorting

### DIFF
--- a/src/app/_components/ColorCodedDropdown.tsx
+++ b/src/app/_components/ColorCodedDropdown.tsx
@@ -94,7 +94,9 @@ export function ColorCodedDropdown({
           </button>
           
           {/* Server Options */}
-          {servers.map((server) => (
+          {servers
+            .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''))
+            .map((server) => (
             <button
               key={server.id}
               type="button"

--- a/src/app/_components/SettingsModal.tsx
+++ b/src/app/_components/SettingsModal.tsx
@@ -31,7 +31,11 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
         throw new Error('Failed to fetch servers');
       }
       const data = await response.json();
-      setServers(data as Server[]);
+      // Sort servers by name alphabetically
+      const sortedServers = (data as Server[]).sort((a, b) => 
+        (a.name ?? '').localeCompare(b.name ?? '')
+      );
+      setServers(sortedServers);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {


### PR DESCRIPTION
## Summary

This PR adds a confirmation modal before script execution when only one server is saved, and implements alphabetical sorting of servers by name.

## Changes

### Confirmation Modal
- **Single Server**: Shows confirmation modal with script name and server details
- **Multiple Servers**: Preserves existing behavior with server selection dropdown
- **Auto-selection**: Single server is auto-selected but requires user confirmation
- **No Auto-execution**: Removed immediate execution when only one server exists

### Server Sorting
- **Alphabetical Order**: Servers are now sorted by name (PROX2 before PROX3)
- **Consistent Sorting**: Applied across all components (dropdown, settings modal, confirmation modal)
- **Safe Sorting**: Uses nullish coalescing operators for proper handling of undefined names

## Technical Details

- Modified  to show confirmation UI for single server scenario
- Updated  and  with server sorting
- Fixed ESLint issues with nullish coalescing operators
- Maintained SSH mode as the only execution method

## Testing

- ✅ Build passes successfully
- ✅ No linting errors
- ✅ TypeScript compilation successful
- ✅ Confirmation modal displays correctly for single server
- ✅ Server sorting works in all components

## Screenshots

**Single Server Confirmation:**
- Shows script name prominently
- Displays server details (name, IP) in styled card
- "Install" and "Cancel" buttons

**Multiple Servers:**
- Server selection dropdown with no pre-selection
- "Run on Server" button (disabled until selection)

Fixes the issue where PROX3 appeared before PROX2 in server lists.