### PR TITLE
hotfix: add DATABASE_URL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,4 @@ AUTH_PASSWORD_HASH=
 AUTH_ENABLED=false
 AUTH_SETUP_COMPLETED=false
 JWT_SECRET=
+DATABASE_URL="file:./data/database.sqlite"


### PR DESCRIPTION
## Summary

This hotfix adds the missing DATABASE_URL to the .env.example file to ensure new installations have the required Prisma database configuration.

## Changes

- Added DATABASE_URL="file:./data/database.sqlite" to .env.example
- Ensures new users have the required Prisma database URL configured by default

## Technical Details

- DATABASE_URL is required for Prisma client generation
- This complements the update.sh fix that handles existing installations
- New installations will now have the proper database configuration from the start

## Testing

- .env.example now includes DATABASE_URL
- New installations will work out of the box with Prisma