### PR TITLE
fix/185: normalize script matching to handle underscore vs hyphen differences

### DIFF
--- a/src/server/api/routers/scripts.ts
+++ b/src/server/api/routers/scripts.ts
@@ -177,6 +177,15 @@ export const scriptsRouter = createTRPCRouter({
           const firstInstallMethod = script?.install_methods?.[0];
           const os = firstInstallMethod?.resources?.os;
           const version = firstInstallMethod?.resources?.version;
+          // Extract install basenames for robust local matching (e.g., execute.sh -> execute)
+          const install_basenames = (script?.install_methods ?? [])
+            .map(m => m?.script)
+            .filter((p): p is string => typeof p === 'string')
+            .map(p => {
+              const parts = p.split('/');
+              const file = parts[parts.length - 1] ?? '';
+              return file.replace(/\.(sh|bash|py|js|ts)$/i, '');
+            });
           
           return {
             ...card,
@@ -189,6 +198,7 @@ export const scriptsRouter = createTRPCRouter({
             version: version,
             // Add interface port
             interface_port: script?.interface_port,
+            install_basenames,
           } as ScriptCard;
         });
 

--- a/src/types/script.ts
+++ b/src/types/script.ts
@@ -60,6 +60,8 @@ export interface ScriptCard {
   os?: string;
   version?: string;
   interface_port?: number | null;
+  // Optional: basenames of install scripts (without extension)
+  install_basenames?: string[];
 }
 
 export interface GitHubFile {


### PR DESCRIPTION
## Problem
PVE Host scripts were showing as 'Not Downloaded' in the Downloaded tab even when they were actually downloaded locally. This occurred because:

- Local filenames use underscores (e.g., `pbs_microcode.sh`)
- JSON slugs use hyphens (e.g., `pbs-microcode`)
- The matching logic was doing raw string comparisons

## Solution
- Added `normalizeId` helper that converts identifiers to lowercase and replaces non-alphanumeric characters with hyphens
- Enhanced script cards to include `install_basenames` extracted from `install_methods`
- Updated both `DownloadedScriptsTab` and `ScriptsGrid` to use normalized comparisons
- Now matches against script `name`, `slug`, or any `install_basenames`

## Testing
- Download all scripts
- Go to Downloaded tab
- Filter by 'PVE Host' category
- Scripts like 'PVE LXC Execute Command' and 'PBS Processor Microcode' now correctly show as 'Downloaded'

Fixes the issue where PVE Host scripts appeared as 'Not Downloaded' despite being available locally.