### PR TITLE
fix/184 script filtering count discrepancy

### DIFF
--- a/src/app/_components/DownloadedScriptsTab.tsx
+++ b/src/app/_components/DownloadedScriptsTab.tsx
@@ -275,7 +275,11 @@ export function DownloadedScriptsTab({ onInstallScript }: DownloadedScriptsTabPr
       scripts = scripts.filter(script => {
         if (!script) return false;
         const scriptType = (script.type ?? '').toLowerCase();
-        return filters.selectedTypes.some(type => type.toLowerCase() === scriptType);
+        
+        // Map non-standard types to standard categories
+        const mappedType = scriptType === 'turnkey' ? 'ct' : scriptType;
+        
+        return filters.selectedTypes.some(type => type.toLowerCase() === mappedType);
       });
     }
 

--- a/src/app/_components/ScriptsGrid.tsx
+++ b/src/app/_components/ScriptsGrid.tsx
@@ -303,7 +303,11 @@ export function ScriptsGrid({ onInstallScript }: ScriptsGridProps) {
       scripts = scripts.filter(script => {
         if (!script) return false;
         const scriptType = (script.type ?? '').toLowerCase();
-        return filters.selectedTypes.some(type => type.toLowerCase() === scriptType);
+        
+        // Map non-standard types to standard categories
+        const mappedType = scriptType === 'turnkey' ? 'ct' : scriptType;
+        
+        return filters.selectedTypes.some(type => type.toLowerCase() === mappedType);
       });
     }
 


### PR DESCRIPTION
## Problem
When filtering downloaded scripts by type with all 4 categories selected, the count showed '398 of 399 scripts' instead of '399 of 399 scripts'.

## Root Cause
The TurnKey script has type 'turnkey' which doesn't match any of the four filter categories (ct, vm, addon, pve), causing it to be excluded from filtered results even when all categories are selected.

## Solution
- Map 'turnkey' script type to 'ct' (LXC Container) category in filtering logic
- Applied fix to both DownloadedScriptsTab and ScriptsGrid components
- TurnKey script is LXC-related so mapping to 'ct' is appropriate

## Testing
- Verified only one script has non-standard type ('turnkey')
- Tested filtering logic to confirm fix works correctly
- Now shows correct count: '399 of 399 scripts' when all types selected

Fixes the filtering count discrepancy issue.