### PR TITLE
fix: improve toggle slider visibility with better contrast and blue ON state

### DIFF
--- a/src/app/_components/ui/toggle.tsx
+++ b/src/app/_components/ui/toggle.tsx
@@ -22,10 +22,10 @@ const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>(
             {...props}
           />
           <div className={cn(
-            "w-11 h-6 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/20 rounded-full peer after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 dark:after:border-gray-500 after:border after:rounded-full after:h-5 after:w-5 after:transition-transform after:duration-300 after:ease-in-out transition-colors duration-300 ease-in-out",
+            "w-11 h-6 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary/20 rounded-full peer after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 dark:after:border-gray-500 after:border after:rounded-full after:h-5 after:w-5 after:transition-transform after:duration-300 after:ease-in-out after:shadow-md transition-colors duration-300 ease-in-out border-2 border-gray-300 dark:border-gray-600",
             checked 
-              ? "bg-primary after:translate-x-full" 
-              : "bg-gray-200 dark:bg-gray-600",
+              ? "bg-blue-500 dark:bg-blue-600 after:translate-x-full" 
+              : "bg-gray-300 dark:bg-gray-700",
             className
           )} />
         </label>


### PR DESCRIPTION
## Problem
The toggle sliders in the settings modal had low contrast, making it difficult to distinguish between ON and OFF states at a glance.

## Solution
Enhanced the toggle component styling to improve visibility:

### Changes Made:
1. **Darkened OFF state background**:
   - Changed from bg-gray-200 to bg-gray-300 (light mode)
   - Changed from dark:bg-gray-600 to dark:bg-gray-700 (dark mode)

2. **Added border to the track** for better definition:
   - Added border-2 class
   - Added border-gray-300 dark:border-gray-600 for subtle outline

3. **Enhanced the slider knob contrast**:
   - Added after:shadow-md to make the white knob stand out more against the background

4. **Improved ON state visibility**:
   - Changed from bg-primary to bg-blue-500 dark:bg-blue-600 for vibrant blue color
   - Makes toggle states immediately distinguishable at a glance

## Testing
- Toggle switches now have much better contrast in both light and dark modes
- ON state shows vibrant blue background
- OFF state shows darker gray background with clear border
- Slider knob has shadow for better visibility

Fixes the visibility issue where users had to look closely to determine toggle state.