### PR TITLE
Fix: Include 'New' scripts in Download All Filtered when no filters are active

### DIFF
--- a/src/app/_components/ScriptsGrid.tsx
+++ b/src/app/_components/ScriptsGrid.tsx
@@ -535,7 +535,30 @@ export function ScriptsGrid({ onInstallScript }: ScriptsGridProps) {
   };
 
   const handleDownloadAllFiltered = () => {
-    const slugsToDownload = filteredScripts.map(script => script.slug).filter(Boolean);
+
+    let scriptsToDownload: ScriptCardType[] = filteredScripts;
+    
+    if (!hasActiveFilters) {
+ 
+      const scriptMap = new Map<string, ScriptCardType>();
+
+      filteredScripts.forEach(script => {
+        if (script?.slug) {
+          scriptMap.set(script.slug, script);
+        }
+      });
+      
+
+      newestScripts.forEach(script => {
+        if (script?.slug && !scriptMap.has(script.slug)) {
+          scriptMap.set(script.slug, script);
+        }
+      });
+      
+      scriptsToDownload = Array.from(scriptMap.values());
+    }
+    
+    const slugsToDownload = scriptsToDownload.map(script => script.slug).filter(Boolean);
     if (slugsToDownload.length > 0) {
       void downloadScriptsIndividually(slugsToDownload);
     }


### PR DESCRIPTION
## Problem
When no filters are active, clicking 'Download All Filtered' only downloads scripts from the lower section (main grid) and excludes scripts from the 'Newest Scripts' carousel.

## Solution
Modified `handleDownloadAllFiltered` to include all scripts when no filters are active:
- When no filters are active: Combines `filteredScripts` and `newestScripts` (deduplicated by slug)
- When filters are active: Uses `filteredScripts` as before (maintains existing behavior)

## Changes
- Updated `handleDownloadAllFiltered` in `ScriptsGrid.tsx` to check if filters are active
- When no filters are active, merges both filtered and newest scripts to ensure all scripts are included
- Ensures no duplicate scripts are downloaded

## Testing
- ✅ No filters active: All scripts (including 'New' carousel) are downloaded
- ✅ Filters active: Only filtered scripts are downloaded (existing behavior maintained)