### PR TITLE
Fix stale LXC entries and improve orphaned script cleanup

### DIFF
--- a/src/app/_components/InstalledScriptsTab.tsx
+++ b/src/app/_components/InstalledScriptsTab.tsx
@@ -937,6 +937,18 @@ export function InstalledScriptsTab() {
           </Button>
           <Button
             onClick={() => {
+              cleanupRunRef.current = false; // Allow cleanup to run again
+              void cleanupMutation.mutate();
+            }}
+            disabled={cleanupMutation.isPending}
+            variant="outline"
+            size="default"
+            className="border-warning/30 text-warning hover:bg-warning/10"
+          >
+            {cleanupMutation.isPending ? '🧹 Cleaning up...' : '🧹 Cleanup Orphaned Scripts'}
+          </Button>
+          <Button
+            onClick={() => {
               // Trigger status check by calling the mutation directly
               const serverIds = [...new Set(scripts
                 .filter(script => script.server_id)


### PR DESCRIPTION
## Problem
- Deleted LXC containers (like Planka) were still showing in the installed scripts list
- New LXC installations weren't showing container ID or IP address correctly
- Cleanup function was not reliably detecting deleted containers

## Solution
- **Improved cleanup function**: Now uses `pct list` to verify containers exist (more reliable than checking config files)
- **Batch processing**: Groups scripts by server for more efficient checking
- **Double-check logic**: Verifies both `pct list` and config file existence before deletion
- **Manual cleanup button**: Added "🧹 Cleanup Orphaned Scripts" button for on-demand cleanup
- **Better error handling**: Improved logging and error handling throughout the cleanup process

## Changes
- Modified `cleanupOrphanedScripts` to use `pct list` for container verification
- Added batch processing by server to reduce SSH connections
- Added manual cleanup button in Installed Scripts tab
- Improved error handling and logging

## Testing
- Cleanup function now properly detects and removes orphaned scripts
- Manual cleanup button allows users to trigger cleanup on-demand
- Better reliability when checking if containers exist on Proxmox servers