### PR TITLE
feat: Add Interface Port display to script detail modal header

### DIFF
--- a/src/app/_components/ScriptDetailModal.tsx
+++ b/src/app/_components/ScriptDetailModal.tsx
@@ -165,6 +165,20 @@ export function ScriptDetailModal({
                 {script.privileged && <PrivilegedBadge />}
               </div>
             </div>
+            
+            {/* Interface Port*/}
+            {script.interface_port && (
+              <div className="ml-3 sm:ml-4 flex-shrink-0">
+                <div className="bg-primary/10 border border-primary/30 rounded-lg px-3 py-1.5 sm:px-4 sm:py-2">
+                  <span className="text-xs sm:text-sm font-medium text-muted-foreground mr-2">
+                    Port:
+                  </span>
+                  <span className="text-sm sm:text-base font-semibold text-foreground font-mono">
+                    {script.interface_port}
+                  </span>
+                </div>
+              </div>
+            )}
           </div>
           
           {/* Close Button */}


### PR DESCRIPTION
## Changes
- Added Interface Port display to the header section of the script detail modal
- Positioned port close to the script name/logo for better visibility
- Port is displayed in a styled badge format for prominence
- Port display remains in Basic Information section as well

## Purpose
Makes the interface port more visible by displaying it in the header next to the script name, while keeping it in the Basic Information section for reference.

## Testing
- Verified port displays correctly in header when interface_port is available
- Verified port still appears in Basic Information section
- Tested responsive layout on different screen sizes