### PR TITLE
Fix: Add minimize buttons to FilterBar and Newest Scripts sections

### DIFF
--- a/src/app/_components/FilterBar.tsx
+++ b/src/app/_components/FilterBar.tsx
@@ -41,6 +41,7 @@ export function FilterBar({
 }: FilterBarProps) {
   const [isTypeDropdownOpen, setIsTypeDropdownOpen] = useState(false);
   const [isSortDropdownOpen, setIsSortDropdownOpen] = useState(false);
+  const [isMinimized, setIsMinimized] = useState(false);
 
   const updateFilters = (updates: Partial<FilterState>) => {
     onFiltersChange({ ...filters, ...updates });
@@ -98,44 +99,17 @@ export function FilterBar({
       {!isLoadingFilters && (
         <div className="mb-4 flex items-center justify-between">
           <h3 className="text-lg font-medium text-foreground">Filter Scripts</h3>
-          <ContextualHelpIcon section="available-scripts" tooltip="Help with filtering and searching" />
-        </div>
-      )}
-
-      {/* Search Bar */}
-      <div className="mb-4">
-        <div className="relative max-w-md w-full">
-          <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-            <svg
-              className="h-5 w-5 text-muted-foreground"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-              />
-            </svg>
-          </div>
-          <input
-            type="text"
-            placeholder="Search scripts..."
-            value={filters.searchQuery}
-            onChange={(e) => updateFilters({ searchQuery: e.target.value })}
-            className="block w-full rounded-lg border border-input bg-background py-3 pr-10 pl-10 text-sm leading-5 text-foreground placeholder-muted-foreground focus:border-primary focus:placeholder-muted-foreground focus:ring-2 focus:ring-primary focus:outline-none"
-          />
-          {filters.searchQuery && (
+          <div className="flex items-center gap-2">
+            <ContextualHelpIcon section="available-scripts" tooltip="Help with filtering and searching" />
             <Button
-              onClick={() => updateFilters({ searchQuery: "" })}
+              onClick={() => setIsMinimized(!isMinimized)}
               variant="ghost"
               size="icon"
-              className="absolute inset-y-0 right-0 pr-3 text-muted-foreground hover:text-foreground"
+              className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              title={isMinimized ? "Expand filters" : "Minimize filters"}
             >
               <svg
-                className="h-5 w-5"
+                className={`h-4 w-4 transition-transform ${isMinimized ? "" : "rotate-180"}`}
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -144,16 +118,69 @@ export function FilterBar({
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   strokeWidth={2}
-                  d="M6 18L18 6M6 6l12 12"
+                  d="M5 15l7-7 7 7"
                 />
               </svg>
             </Button>
-          )}
+          </div>
         </div>
-      </div>
+      )}
 
-      {/* Filter Buttons */}
-      <div className="mb-4 flex flex-col sm:flex-row flex-wrap gap-2 sm:gap-3">
+      {/* Filter Content - Conditionally rendered based on minimized state */}
+      {!isMinimized && !isLoadingFilters && (
+        <>
+          {/* Search Bar */}
+          <div className="mb-4">
+            <div className="relative max-w-md w-full">
+              <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                <svg
+                  className="h-5 w-5 text-muted-foreground"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                  />
+                </svg>
+              </div>
+              <input
+                type="text"
+                placeholder="Search scripts..."
+                value={filters.searchQuery}
+                onChange={(e) => updateFilters({ searchQuery: e.target.value })}
+                className="block w-full rounded-lg border border-input bg-background py-3 pr-10 pl-10 text-sm leading-5 text-foreground placeholder-muted-foreground focus:border-primary focus:placeholder-muted-foreground focus:ring-2 focus:ring-primary focus:outline-none"
+              />
+              {filters.searchQuery && (
+                <Button
+                  onClick={() => updateFilters({ searchQuery: "" })}
+                  variant="ghost"
+                  size="icon"
+                  className="absolute inset-y-0 right-0 pr-3 text-muted-foreground hover:text-foreground"
+                >
+                  <svg
+                    className="h-5 w-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </Button>
+              )}
+            </div>
+          </div>
+
+          {/* Filter Buttons */}
+          <div className="mb-4 flex flex-col sm:flex-row flex-wrap gap-2 sm:gap-3">
         {/* Updateable Filter */}
         <Button
           onClick={() => {
@@ -431,6 +458,8 @@ export function FilterBar({
           </Button>
         )}
       </div>
+        </>
+      )}
 
       {/* Click outside to close dropdowns */}
       {(isTypeDropdownOpen || isSortDropdownOpen) && (

--- a/src/app/_components/ScriptsGrid.tsx
+++ b/src/app/_components/ScriptsGrid.tsx
@@ -34,6 +34,7 @@ export function ScriptsGrid({ onInstallScript }: ScriptsGridProps) {
   });
   const [saveFiltersEnabled, setSaveFiltersEnabled] = useState(false);
   const [isLoadingFilters, setIsLoadingFilters] = useState(true);
+  const [isNewestMinimized, setIsNewestMinimized] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
 
   const { data: scriptCardsData, isLoading: githubLoading, error: githubError, refetch } = api.scripts.getScriptCardsWithCategories.useQuery();
@@ -689,8 +690,8 @@ export function ScriptsGrid({ onInstallScript }: ScriptsGridProps) {
           onViewModeChange={setViewMode}
         />
 
-        {/* Newest Scripts Carousel - Always show when there are newest scripts */}
-        {newestScripts.length > 0 && (
+        {/* Newest Scripts Carousel - Only show when no search, filters, or category is active */}
+        {newestScripts.length > 0 && !hasActiveFilters && !selectedCategory && (
           <div className="mb-8">
             <div className="bg-card border-l-4 border-l-primary border border-border rounded-lg p-6 shadow-lg">
               <div className="flex items-center justify-between mb-4">
@@ -698,39 +699,64 @@ export function ScriptsGrid({ onInstallScript }: ScriptsGridProps) {
                   <Clock className="h-6 w-6 text-primary" />
                   Newest Scripts
                 </h2>
-                <span className="text-sm text-muted-foreground">
-                  {newestScripts.length} recently added
-                </span>
-              </div>
-              
-              <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent">
-                <div className="flex gap-4 pb-2" style={{ minWidth: 'max-content' }}>
-                  {newestScripts.map((script, index) => {
-                    if (!script || typeof script !== 'object') {
-                      return null;
-                    }
-                    
-                    const uniqueKey = `newest-${script.slug ?? 'unknown'}-${script.name ?? 'unnamed'}-${index}`;
-                    
-                    return (
-                      <div key={uniqueKey} className="flex-shrink-0 w-64 sm:w-72 md:w-80">
-                        <div className="relative">
-                          <ScriptCard
-                            script={script}
-                            onClick={handleCardClick}
-                            isSelected={selectedSlugs.has(script.slug ?? '')}
-                            onToggleSelect={toggleScriptSelection}
-                          />
-                          {/* NEW badge */}
-                          <div className="absolute top-2 right-2 bg-success text-success-foreground text-xs font-semibold px-2 py-1 rounded-md shadow-md z-10">
-                            NEW
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
+                <div className="flex items-center gap-2">
+                  <span className="text-sm text-muted-foreground">
+                    {newestScripts.length} recently added
+                  </span>
+                  <Button
+                    onClick={() => setIsNewestMinimized(!isNewestMinimized)}
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                    title={isNewestMinimized ? "Expand newest scripts" : "Minimize newest scripts"}
+                  >
+                    <svg
+                      className={`h-4 w-4 transition-transform ${isNewestMinimized ? "" : "rotate-180"}`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M5 15l7-7 7 7"
+                      />
+                    </svg>
+                  </Button>
                 </div>
               </div>
+              
+              {!isNewestMinimized && (
+                <div className="overflow-x-auto scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent">
+                  <div className="flex gap-4 pb-2" style={{ minWidth: 'max-content' }}>
+                    {newestScripts.map((script, index) => {
+                      if (!script || typeof script !== 'object') {
+                        return null;
+                      }
+                      
+                      const uniqueKey = `newest-${script.slug ?? 'unknown'}-${script.name ?? 'unnamed'}-${index}`;
+                      
+                      return (
+                        <div key={uniqueKey} className="flex-shrink-0 w-64 sm:w-72 md:w-80">
+                          <div className="relative">
+                            <ScriptCard
+                              script={script}
+                              onClick={handleCardClick}
+                              isSelected={selectedSlugs.has(script.slug ?? '')}
+                              onToggleSelect={toggleScriptSelection}
+                            />
+                            {/* NEW badge */}
+                            <div className="absolute top-2 right-2 bg-success text-success-foreground text-xs font-semibold px-2 py-1 rounded-md shadow-md z-10">
+                              NEW
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Changes

- Add minimize/collapse functionality to FilterBar component
  - Users can now minimize the filter section to save screen space
  - Minimize button with chevron icon in the header
  
- Add minimize/collapse functionality to Newest Scripts section
  - Users can now minimize the newest scripts carousel
  - Minimize button with chevron icon in the header

- Conditional display for Newest Scripts section
  - Newest Scripts section is now only shown when:
    - User is not searching
    - User has no active filters
    - User is not viewing a category
  - This prevents the section from appearing when it's not relevant

## Benefits

- Better UX: Users can minimize sections they don't need to see
- Cleaner interface: Newest Scripts only shows when appropriate
- More screen space: Minimized sections take up less vertical space