### PR TITLE
Fix x button vertical centering in filter scripts search bar

### DIFF
--- a/src/app/_components/FilterBar.tsx
+++ b/src/app/_components/FilterBar.tsx
@@ -158,8 +158,7 @@ export function FilterBar({
                 <Button
                   onClick={() => updateFilters({ searchQuery: "" })}
                   variant="ghost"
-                  size="icon"
-                  className="absolute inset-y-0 right-0 pr-3 text-muted-foreground hover:text-foreground"
+                  className="absolute inset-y-0 right-0 flex items-center justify-center pr-3 h-full text-muted-foreground hover:text-foreground"
                 >
                   <svg
                     className="h-5 w-5"


### PR DESCRIPTION
## Changes
- Fixed vertical centering of the x (clear) button in the filter scripts search bar
- Removed `size='icon'` constraint that was limiting button height to 36px
- Changed positioning to use `inset-y-0` with `h-full` to match the full input field height
- Added `flex items-center justify-center` for proper icon centering within the button

## Fixes
- Button now properly centers vertically within the input field
- Hover background now matches the full input height in both light and dark themes
- Resolves issue where hover background appeared shorter than the input field

## Testing
- Verified button is vertically centered
- Verified hover state background matches input height in both themes