### PR TITLE
feat: Add delete script functionality

### DIFF
--- a/src/server/api/routers/scripts.ts
+++ b/src/server/api/routers/scripts.ts
@@ -363,6 +363,34 @@ export const scriptsRouter = createTRPCRouter({
       }
     }),
 
+  // Delete script files
+  deleteScript: publicProcedure
+    .input(z.object({ slug: z.string() }))
+    .mutation(async ({ input }) => {
+      try {
+        // Get the script details
+        const script = await localScriptsService.getScriptBySlug(input.slug);
+        if (!script) {
+          return {
+            success: false,
+            error: 'Script not found',
+            deletedFiles: []
+          };
+        }
+
+        // Delete the script files
+        const result = await scriptDownloaderService.deleteScript(script);
+        return result;
+      } catch (error) {
+        console.error('Error in deleteScript:', error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to delete script',
+          deletedFiles: []
+        };
+      }
+    }),
+
   // Compare local and remote script content
   compareScriptContent: publicProcedure
     .input(z.object({ slug: z.string() }))


### PR DESCRIPTION
This PR adds the ability to delete downloaded script files from the ScriptDetailModal.

## Changes
- Added `deleteScript` method to ScriptDownloaderService (both TypeScript and JavaScript versions)
- Added `deleteScript` API endpoint to scripts router
- Added delete button to ScriptDetailModal with confirmation modal
- Uses ConfirmationModal component instead of plain window.confirm
- Delete button only shows when script files exist locally
- Includes proper error handling and success/error messages

## Testing
- Delete button appears when script files are downloaded
- Confirmation modal appears when clicking delete
- Script files are successfully deleted
- UI updates after deletion to reflect file removal