### PR TITLE
Fix script slug matching to prevent false positives

### DIFF
--- a/src/app/_components/DownloadedScriptsTab.tsx
+++ b/src/app/_components/DownloadedScriptsTab.tsx
@@ -185,13 +185,19 @@ export function DownloadedScriptsTab({ onInstallScript }: DownloadedScriptsTabPr
         // Check if there's a corresponding local script
         const hasLocalVersion = localScriptsData?.scripts?.some(local => {
           if (!local?.name) return false;
+          
+          // Primary: Exact slug-to-slug matching (most reliable, prevents false positives)
+          if (local.slug && script.slug) {
+            if (local.slug.toLowerCase() === script.slug.toLowerCase()) {
+              return true;
+            }
+          }
+          
+          // Secondary: Check install basenames (for edge cases where install script names differ from slugs)
+          // Only use normalized matching for install basenames, not for slug/name matching
           const normalizedLocal = normalizeId(local.name);
-          const matchesNameOrSlug = (
-            normalizedLocal === normalizeId(script.name) ||
-            normalizedLocal === normalizeId(script.slug)
-          );
           const matchesInstallBasename = (script as any)?.install_basenames?.some((base: string) => normalizeId(base) === normalizedLocal) ?? false;
-          return matchesNameOrSlug || matchesInstallBasename;
+          return matchesInstallBasename;
         }) ?? false;
         
         return {

--- a/src/app/_components/ScriptsGrid.tsx
+++ b/src/app/_components/ScriptsGrid.tsx
@@ -216,13 +216,19 @@ export function ScriptsGrid({ onInstallScript }: ScriptsGridProps) {
       // Check if there's a corresponding local script
       const hasLocalVersion = localScriptsData?.scripts?.some(local => {
         if (!local?.name) return false;
+        
+        // Primary: Exact slug-to-slug matching (most reliable, prevents false positives)
+        if (local.slug && script.slug) {
+          if (local.slug.toLowerCase() === script.slug.toLowerCase()) {
+            return true;
+          }
+        }
+        
+        // Secondary: Check install basenames (for edge cases where install script names differ from slugs)
+        // Only use normalized matching for install basenames, not for slug/name matching
         const normalizedLocal = normalizeId(local.name);
-        const matchesNameOrSlug = (
-          normalizedLocal === normalizeId(script.name) ||
-          normalizedLocal === normalizeId(script.slug)
-        );
         const matchesInstallBasename = (script as any)?.install_basenames?.some((base: string) => normalizeId(base) === normalizedLocal) ?? false;
-        return matchesNameOrSlug || matchesInstallBasename;
+        return matchesInstallBasename;
       }) ?? false;
       
       return {


### PR DESCRIPTION
## Problem
Downloaded scripts were incorrectly matched using normalized name matching, causing scripts with similar slugs (like 'docker-vm') to appear when loading a different script (like 'docker').

## Root Cause
The matching logic used normalized slug/name matching as a fallback, which could cause false matches. For example, when only `ct/docker.sh` was downloaded, the system would incorrectly show `docker-vm` as downloaded.

## Solution
- Removed the problematic normalized slug/name matching fallback
- Use exact slug-to-slug matching as the primary method
- Only use install basename matching for edge cases where install script names differ from slugs
- This ensures only exact matches are allowed, preventing substring/starts-with false matches

## Testing
- Load script with slug 'docker'
- Ensure 'docker-vm' does not appear in downloaded scripts list
- Only scripts with exact slug matches should appear