### PR TITLE
core: remove uv cache clean | remove log rotation 

### DIFF
--- a/scripts/core/core.func
+++ b/scripts/core/core.func
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2021-2025 community-scripts ORG
 # License: MIT | https://raw.githubusercontent.com/community-scripts/ProxmoxVE/main/LICENSE
 
@@ -453,3 +452,6 @@ check_or_create_swap() {
 }
 
 trap 'stop_spinner' EXIT INT TERM
+
+# Initialize functions when core.func is sourced
+load_functions


### PR DESCRIPTION
<!--🛑 All Pull Requests need to made against the development branch. PRs against main will get closed. -->
## ✍️ Description  
Removed the cache clean command for uv.
UV uses aggresive cache methods, so it can be only cleared with --force, thats in my opinion to unsafe for productive usage:

Example:
root@paperless-ngx:~# uv cache prune
Cache is currently in-use, waiting for other uv processes to finish (use --force to override)

Example with force:
root@paperless-ngx:~# uv cache clean --force
Clearing cache at: .cache/uv
Removed 118567 files (1.4GiB)

_______________

remove log rotation, because some apps need the journalctl to get login data or api key


## 🔗 Related PR / Issue  
Link: Upstream:  https://github.com/community-scripts/ProxmoxVE/pull/9413/


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

## Screenshot for frontend Change

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
