### PR TITLE
Add VM status check and UI improvements

### DIFF
--- a/src/app/_components/ScriptInstallationCard.tsx
+++ b/src/app/_components/ScriptInstallationCard.tsx
@@ -33,6 +33,7 @@ interface InstalledScript {
   container_status?: 'running' | 'stopped' | 'unknown';
   web_ui_ip: string | null;
   web_ui_port: number | null;
+  is_vm?: boolean;
 }
 
 interface ScriptInstallationCardProps {
@@ -300,7 +301,7 @@ export function ScriptInstallationCard({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent className="w-48 bg-card border-border">
-                  {script.container_id && (
+                  {script.container_id && !script.is_vm && (
                     <DropdownMenuItem
                       onClick={onUpdate}
                       disabled={containerStatus === 'stopped'}
@@ -318,7 +319,7 @@ export function ScriptInstallationCard({
                       Backup
                     </DropdownMenuItem>
                   )}
-                  {script.container_id && script.execution_mode === 'ssh' && (
+                  {script.container_id && script.execution_mode === 'ssh' && !script.is_vm && (
                     <DropdownMenuItem
                       onClick={onShell}
                       disabled={containerStatus === 'stopped'}


### PR DESCRIPTION
This PR adds support for VM status checking and improves the UI to differentiate between LXC containers and VMs.

## Changes
- Add VM status checking using `qm status` command
- Hide update button for VMs (only show for LXC containers)
- Hide shell button for VMs (only show for LXC containers)  
- Hide LXC Settings option for VMs
- Display VM/LXC indicator badges in table before script names
- Update statistics cards to differentiate between LXC and VMs
- Update container control to support both `pct` (LXC) and `qm` (VM) commands
- Improve status parsing to handle both container types

## Testing
- Verified VM status checking works with `qm status`
- Verified LXC status checking still works with `pct status`
- Verified UI correctly hides/shows buttons based on container type
- Verified statistics cards show correct counts for LXC and VMs separately