### PR TITLE
fix: pct create fails with malformed arguments (#423)

### DIFF
--- a/scripts/core/build.func
+++ b/scripts/core/build.func
@@ -517,11 +517,16 @@ base_settings() {
     fi
   fi
 
-  MTU=${var_mtu:-""}
-  SD=${var_storage:-""}
-  NS=${var_ns:-""}
-  MAC=${var_mac:-""}
-  VLAN=${var_vlan:-""}
+  # Format optional network variables with proper prefixes for pct create
+  # Also strip any spaces from nameserver values (multiple IPs must be comma-separated without spaces)
+  local _ns_clean="${var_ns:-}"
+  _ns_clean="${_ns_clean// /}" # Remove all spaces from nameserver value
+
+  [[ -n "${var_mtu:-}" ]] && MTU=",mtu=${var_mtu}" || MTU=""
+  [[ -n "${var_searchdomain:-}" ]] && SD="-searchdomain=${var_searchdomain}" || SD=""
+  [[ -n "$_ns_clean" ]] && NS="-nameserver=${_ns_clean}" || NS=""
+  [[ -n "${var_mac:-}" ]] && MAC=",hwaddr=${var_mac}" || MAC=""
+  [[ -n "${var_vlan:-}" ]] && VLAN=",tag=${var_vlan}" || VLAN=""
   SSH=${var_ssh:-"no"}
   SSH_AUTHORIZED_KEY=${var_ssh_authorized_key:-""}
   UDHCPC_FIX=${var_udhcpc_fix:-""}
@@ -2023,10 +2028,11 @@ Advanced:
   var_apt_cacher="$_apt_cacher"
   var_apt_cacher_ip="$_apt_cacher_ip"
 
-  # Format optional values
+  # Format optional values (strip spaces from nameserver - multiple IPs must be comma-separated without spaces)
+  local _ns_clean="${_ns// /}"
   [[ -n "$_mtu" ]] && MTU=",mtu=$_mtu" || MTU=""
   [[ -n "$_sd" ]] && SD="-searchdomain=$_sd" || SD=""
-  [[ -n "$_ns" ]] && NS="-nameserver=$_ns" || NS=""
+  [[ -n "$_ns_clean" ]] && NS="-nameserver=$_ns_clean" || NS=""
   [[ -n "$_mac" ]] && MAC=",hwaddr=$_mac" || MAC=""
   [[ -n "$_vlan" ]] && VLAN=",tag=$_vlan" || VLAN=""
 

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -1,8 +1,21 @@
 import 'dotenv/config'
 import { PrismaClient } from '../../prisma/generated/prisma/client.ts'
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+import { existsSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
 
 const globalForPrisma = globalThis;
+
+// Ensure database directory exists before initializing Prisma
+// DATABASE_URL format: file:/path/to/database.db
+const dbUrl = process.env.DATABASE_URL || 'file:./data/settings.db';
+const dbPath = dbUrl.replace(/^file:/, '');
+const dbDir = dirname(dbPath);
+
+if (!existsSync(dbDir)) {
+  console.log(`Creating database directory: ${dbDir}`);
+  mkdirSync(dbDir, { recursive: true });
+}
 
 const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL });
 

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -1,8 +1,21 @@
 import 'dotenv/config'
 import { PrismaClient } from '../../prisma/generated/prisma/client'
 import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
+import { existsSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
 
 const globalForPrisma = globalThis as { prisma?: PrismaClient };
+
+// Ensure database directory exists before initializing Prisma
+// DATABASE_URL format: file:/path/to/database.db
+const dbUrl = process.env.DATABASE_URL || 'file:./data/settings.db';
+const dbPath = dbUrl.replace(/^file:/, '');
+const dbDir = dirname(dbPath);
+
+if (!existsSync(dbDir)) {
+  console.log(`Creating database directory: ${dbDir}`);
+  mkdirSync(dbDir, { recursive: true });
+}
 
 const adapter = new PrismaBetterSqlite3({ url: process.env.DATABASE_URL! });
 


### PR DESCRIPTION
<!--🛑 All Pull Requests need to made against the development branch. PRs against main will get closed. -->
## ✍️ Description  
- Fix NS/MTU/MAC/VLAN/SD variables missing proper prefixes in base_settings() Variables were passed as raw values instead of formatted pct options (e.g., '192.168.1.1' instead of '-nameserver=192.168.1.1')
- Strip spaces from nameserver values to prevent 'too many arguments' error Multiple DNS servers must be comma-separated without spaces
- Auto-create database directory before Prisma initialization Fixes 'Cannot open database because directory does not exist' error for manual Git installations


## 🔗 Related PR / Issue  
Fixes: #422 
Fixes: #423


## ✅ Prerequisites  (**X** in brackets) 

- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

## Screenshot for frontend Change

---

## 🛠️ Type of Change (**X** in brackets)  

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.  
