### PR TITLE
feat: Add Update all downloaded scripts button

### DIFF
--- a/src/app/_components/DownloadedScriptsTab.tsx
+++ b/src/app/_components/DownloadedScriptsTab.tsx
@@ -66,7 +66,10 @@ export function DownloadedScriptsTab({
       setUpdateResult({
         successCount: data.successful?.length ?? 0,
         failCount: data.failed?.length ?? 0,
-        failed: data.failed ?? [],
+        failed: (data.failed ?? []).map((f) => ({
+          slug: f.slug,
+          error: f.error ?? "Unknown error",
+        })),
       });
       setTimeout(() => setUpdateResult(null), 8000);
     },


### PR DESCRIPTION
Adds a single button on the Downloaded Scripts tab to update all downloaded scripts from GitHub at once, so users don't have to open each script modal and press "Update Script" for 350+ scripts.

- **Button**: "Update all downloaded scripts" above the filter bar
- **Confirmation**: Modal asks to confirm (may take several minutes)
- **Backend**: Uses existing `loadMultipleScripts` API
- **Feedback**: Inline result with success/fail counts; hover for failed slug details
- **Refresh**: Invalidates script lists on success so updatable badges update