### PR TITLE
fix: handle special characters in SSH password/passphrase (Fixes #312)

### DIFF
--- a/src/app/_components/ServerForm.tsx
+++ b/src/app/_components/ServerForm.tsx
@@ -438,6 +438,11 @@ export function ServerForm({
             {errors.password && (
               <p className="text-destructive mt-1 text-sm">{errors.password}</p>
             )}
+            <p className="text-muted-foreground mt-1 text-xs">
+              SSH key is recommended when possible. Special characters (e.g.{" "}
+              <code className="rounded bg-muted px-0.5">{"{ } $ \" '"}</code>) are
+              supported.
+            </p>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
Fixes #312 — script install fails when SSH password contains special characters (e.g. `{`).

## Changes
- **transferScriptsFolder**: Use `sshpass -f` with a temporary file instead of `sshpass -p ${password}` so the password/passphrase never goes through the shell. Temp file is created with mode 0600 and removed in `close`/error/catch.
- **testWithExpect**: Pass password via `SSH_PASSWORD` env var and use `$env(SSH_PASSWORD)` in the expect script so the password is not embedded in the script string (safe for `{`, `}`, `$`, `"`, etc.).
- **ServerForm**: Add hint when password auth is selected: SSH key recommended; special characters supported.

## Testing
- Passwords containing `{`, `}`, `$`, `"`, space, backslash work for script install and connection test.
- Key auth (with/without passphrase) unchanged.