### PR TITLE
fix: use node-specific Proxmox config paths for VM vs LXC (fixes #464)

### DIFF
--- a/server.js
+++ b/server.js
@@ -1153,10 +1153,11 @@ class ScriptExecutionHandler {
         const hostname = hostnames[i];
         
         try {
-          // Read config file to get hostname/name
+          // Read config file to get hostname/name (node-specific path)
+          const nodeName = server.name;
           const configPath = containerType === 'lxc' 
-            ? `/etc/pve/lxc/${nextId}.conf`
-            : `/etc/pve/qemu-server/${nextId}.conf`;
+            ? `/etc/pve/nodes/${nodeName}/lxc/${nextId}.conf`
+            : `/etc/pve/nodes/${nodeName}/qemu-server/${nextId}.conf`;
           
           let configContent = '';
           await new Promise(/** @type {(resolve: (value?: void) => void) => void} */ ((resolve) => {


### PR DESCRIPTION
## Summary
Fixes destroying LXC containers on multi-node Proxmox clusters where VM vs LXC detection used symlink paths that resolve to the wrong node.

## Changes
- **isVM()**: Check node-specific paths `/etc/pve/nodes/<server.name>/qemu-server` and `lxc` first; fall back to `/etc/pve/qemu-server` and `/etc/pve/lxc` for single-node setups.
- **checkConfigAndExtractInfo**, config-existence checks (cleanupOrphanedScripts), **getContainerHostname**, **addClonedContainerToDatabase**: Use node-specific paths.
- **syncLXCConfig** / **updateLXCConfig**: Use node-specific LXC config path.
- **server.js** clone flow: Use node-specific config path when reading hostname/name.

## Issue
Closes #464 — Destroying container was failing with `Configuration file 'nodes/HP/qemu-server/168.conf' does not exist` because the container is LXC (config at `nodes/HP/lxc/168.conf`); the app was incorrectly running `qm destroy` instead of `pct destroy` due to wrong-node path checks.