### PR TITLE
feat: add installation defaults and bridge profiles to settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pve-scripts-local",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pve-scripts-local",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/adapter-better-sqlite3": "^7.6.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Server {
   installed_scripts  InstalledScript[]
   backups            Backup[]
   pbs_credentials    PBSStorageCredential[]
+  install_default    InstallDefault?
   
   @@map("servers")
 }
@@ -145,4 +146,51 @@ model Repository {
   updated_at  DateTime @updatedAt
   
   @@map("repositories")
+}
+
+model InstallDefault {
+  id                    Int      @id @default(autoincrement())
+  name                  String   @default("Global")
+  server_id             Int?     @unique
+
+  // Network
+  var_brg               String?  // Bridge (e.g. vmbr0, vmbr1)
+  var_gateway           String?  // Gateway IP
+  var_ns                String?  // DNS Nameserver
+  var_net_mode          String?  // 'dhcp' or 'static'
+  var_vlan              String?  // VLAN ID
+  var_mtu               Int?     // MTU (default 1500)
+  var_ipv6_method       String?  // 'auto', 'dhcp', 'static', 'none'
+
+  // Identity
+  var_tags              String?  // Default Tags (comma-separated)
+  var_pw                String?  // Default Root Password
+
+  // SSH
+  var_ssh               String?  // 'yes' or 'no'
+  var_ssh_authorized_key String? // SSH Public Key
+
+  // Features
+  var_nesting           Int?     // 0 or 1
+  var_fuse              Int?     // 0 or 1
+  var_keyctl            Int?     // 0 or 1
+  var_tun               String?  // 'yes' or 'no'
+  var_protection        String?  // 'yes' or 'no'
+
+  // System
+  var_timezone          String?  // e.g. Europe/Berlin
+  var_verbose           String?  // 'yes' or 'no'
+  var_apt_cacher        String?  // 'yes' or 'no'
+  var_apt_cacher_ip     String?  // APT Cacher IP/Hostname
+
+  // Storage
+  var_container_storage String?  // e.g. local-zfs
+  var_template_storage  String?  // e.g. local
+
+  server                Server?  @relation(fields: [server_id], references: [id], onDelete: Cascade)
+
+  created_at            DateTime @default(now())
+  updated_at            DateTime @updatedAt
+
+  @@map("install_defaults")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Server {
   backups            Backup[]
   pbs_credentials    PBSStorageCredential[]
   install_default    InstallDefault?
+  bridge_profiles    BridgeProfile[]
   
   @@map("servers")
 }
@@ -193,4 +194,19 @@ model InstallDefault {
   updated_at            DateTime @updatedAt
 
   @@map("install_defaults")
+}
+
+model BridgeProfile {
+  id          Int      @id @default(autoincrement())
+  name        String   // Bridge name (e.g. vmbr0, vmbr1)
+  gateway     String?  // Gateway IP address
+  nameserver  String?  // DNS Nameserver IP
+  server_id   Int?     // null = global, int = per-server
+  server      Server?  @relation(fields: [server_id], references: [id], onDelete: Cascade)
+
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  @@unique([name, server_id])
+  @@map("bridge_profiles")
 }

--- a/scripts/core/build.func
+++ b/scripts/core/build.func
@@ -999,14 +999,19 @@ base_settings() {
 	MTU=${var_mtu:-""}
 	_sd_val="${var_searchdomain:-""}"
 	[[ -n "$_sd_val" ]] && SD="-searchdomain=$_sd_val" || SD=""
-	_ns_val="${var_ns:-""}"
-	[[ -n "$_ns_val" ]] && NS="-nameserver=$_ns_val" || NS=""
+	[[ -n "${var_ns:-}" ]] && NS="-nameserver=${var_ns}" || NS=""
 	MAC=${var_mac:-""}
 	VLAN=${var_vlan:-""}
 	SSH=${var_ssh:-"no"}
 	SSH_AUTHORIZED_KEY=${var_ssh_authorized_key:-""}
 	UDHCPC_FIX=${var_udhcpc_fix:-""}
-	TAGS="community-script,${var_tags:-}"
+	if [[ -n "${var_tags:-}" && "${var_tags}" != *"community-script"* ]]; then
+		TAGS="community-script,${var_tags}"
+	elif [[ -n "${var_tags:-}" ]]; then
+		TAGS="${var_tags}"
+	else
+		TAGS="community-script"
+	fi
 	ENABLE_FUSE=${var_fuse:-"${1:-no}"}
 	ENABLE_TUN=${var_tun:-"${1:-no}"}
 

--- a/src/app/_components/ConfigurationModal.tsx
+++ b/src/app/_components/ConfigurationModal.tsx
@@ -725,10 +725,14 @@ export function ConfigurationModal({
                     <label className="text-foreground mb-2 block text-sm font-medium">
                       Bridge
                     </label>
-                    {bridgeProfiles.length > 0 ? (
+                    {bridgeProfiles.length > 0 && (
                       <select
-                        value={typeof advancedVars.var_brg === 'boolean' ? '' : String(advancedVars.var_brg ?? '')}
+                        value={bridgeProfiles.some((bp: { name: string }) => bp.name === String(advancedVars.var_brg ?? '')) ? String(advancedVars.var_brg ?? '') : '__custom__'}
                         onChange={(e) => {
+                          if (e.target.value === '__custom__') {
+                            updateAdvancedVar('var_brg', '');
+                            return;
+                          }
                           const selected = e.target.value;
                           updateAdvancedVar('var_brg', selected);
                           const match = bridgeProfiles.find((bp: { name: string }) => bp.name === selected);
@@ -737,16 +741,17 @@ export function ConfigurationModal({
                             if (match.nameserver) updateAdvancedVar('var_ns', match.nameserver);
                           }
                         }}
-                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-ring focus:outline-none mb-2"
                       >
-                        <option value="">Select bridge...</option>
                         {bridgeProfiles.map((bp: { id: number; name: string; gateway: string | null; nameserver: string | null }) => (
                           <option key={bp.id} value={bp.name}>
                             {bp.name}{bp.gateway ? ` (GW: ${bp.gateway})` : ''}
                           </option>
                         ))}
+                        <option value="__custom__">Custom...</option>
                       </select>
-                    ) : (
+                    )}
+                    {(bridgeProfiles.length === 0 || !bridgeProfiles.some((bp: { name: string }) => bp.name === String(advancedVars.var_brg ?? ''))) && (
                       <Input
                         type="text"
                         value={typeof advancedVars.var_brg === 'boolean' ? '' : String(advancedVars.var_brg ?? '')}
@@ -756,7 +761,7 @@ export function ConfigurationModal({
                     )}
                     {bridgeProfiles.length > 0 && (
                       <p className="mt-1 text-xs text-muted-foreground">
-                        Selecting a bridge auto-fills Gateway and DNS.
+                        Select a profile or choose &quot;Custom&quot; to enter manually.
                       </p>
                     )}
                   </div>

--- a/src/app/_components/ConfigurationModal.tsx
+++ b/src/app/_components/ConfigurationModal.tsx
@@ -60,6 +60,13 @@ export function ConfigurationModal({
   );
   const installDefaults = installDefaultsData?.defaults as Record<string, string | number | null> | null | undefined;
 
+  // Fetch bridge profiles for the selected server
+  const { data: bridgeProfilesData } = api.bridgeProfiles.getForServer.useQuery(
+    { serverId: server?.id ?? null },
+    { enabled: isOpen && mode === 'advanced' }
+  );
+  const bridgeProfiles = bridgeProfilesData?.profiles ?? [];
+
   // Get resources from JSON
   const resources = actualScript?.install_methods?.[0]?.resources;
   const slug = actualScript?.slug ?? "";
@@ -718,18 +725,40 @@ export function ConfigurationModal({
                     <label className="text-foreground mb-2 block text-sm font-medium">
                       Bridge
                     </label>
-                    <Input
-                      type="text"
-                      value={
-                        typeof advancedVars.var_brg === "boolean"
-                          ? ""
-                          : String(advancedVars.var_brg ?? "")
-                      }
-                      onChange={(e) =>
-                        updateAdvancedVar("var_brg", e.target.value)
-                      }
-                      placeholder="vmbr0"
-                    />
+                    {bridgeProfiles.length > 0 ? (
+                      <select
+                        value={typeof advancedVars.var_brg === 'boolean' ? '' : String(advancedVars.var_brg ?? '')}
+                        onChange={(e) => {
+                          const selected = e.target.value;
+                          updateAdvancedVar('var_brg', selected);
+                          const match = bridgeProfiles.find((bp: { name: string }) => bp.name === selected);
+                          if (match) {
+                            if (match.gateway) updateAdvancedVar('var_gateway', match.gateway);
+                            if (match.nameserver) updateAdvancedVar('var_ns', match.nameserver);
+                          }
+                        }}
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-ring focus:outline-none"
+                      >
+                        <option value="">Select bridge...</option>
+                        {bridgeProfiles.map((bp: { id: number; name: string; gateway: string | null; nameserver: string | null }) => (
+                          <option key={bp.id} value={bp.name}>
+                            {bp.name}{bp.gateway ? ` (GW: ${bp.gateway})` : ''}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <Input
+                        type="text"
+                        value={typeof advancedVars.var_brg === 'boolean' ? '' : String(advancedVars.var_brg ?? '')}
+                        onChange={(e) => updateAdvancedVar('var_brg', e.target.value)}
+                        placeholder="vmbr0"
+                      />
+                    )}
+                    {bridgeProfiles.length > 0 && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Selecting a bridge auto-fills Gateway and DNS.
+                      </p>
+                    )}
                   </div>
                   <div>
                     <label className="text-foreground mb-2 block text-sm font-medium">

--- a/src/app/_components/ConfigurationModal.tsx
+++ b/src/app/_components/ConfigurationModal.tsx
@@ -92,7 +92,7 @@ export function ConfigurationModal({
   // Helper: get install default or hardcoded fallback
   const dflt = (key: string, hardcoded: string | number): string | number => {
     const val = installDefaults?.[key];
-    return (val !== null && val !== undefined) ? val : hardcoded;
+    return val ?? hardcoded;
   };
 
   // Initialize defaults when script/server data is available
@@ -124,7 +124,7 @@ export function ConfigurationModal({
         var_gateway: dflt('var_gateway', '') as string,
         var_ipv6_method: dflt('var_ipv6_method', 'none') as string,
         var_ipv6_static: '',
-        var_vlan: dflt('var_vlan', '') as string | number,
+        var_vlan: dflt('var_vlan', ''),
         var_mtu: dflt('var_mtu', 1500) as number,
         var_mac: '',
         var_ns: dflt('var_ns', '') as string,

--- a/src/app/_components/ConfigurationModal.tsx
+++ b/src/app/_components/ConfigurationModal.tsx
@@ -54,6 +54,7 @@ export function ConfigurationModal({
     );
 
   // Fetch installation defaults (merged: server > global > null)
+  // Only load in advanced mode where user can configure settings
   const { data: installDefaultsData } = api.installDefaults.getForServer.useQuery(
     { serverId: server?.id ?? null },
     { enabled: isOpen && mode === 'advanced' }
@@ -106,6 +107,7 @@ export function ConfigurationModal({
       // Resources always come from script metadata (never from install defaults)
       const defaults: EnvVars = {
         // Resources from JSON (not overridable by install defaults)
+        var_ctid: '',
         var_cpu: resources?.cpu ?? 1,
         var_ram: resources?.ram ?? 1024,
         var_disk: resources?.hdd ?? 4,
@@ -346,6 +348,13 @@ export function ConfigurationModal({
         )
       ) {
         newErrors.var_vlan = "Must be a positive integer";
+      }
+      // Validate CT ID if provided (optional, 100-999999999)
+      if (advancedVars.var_ctid) {
+        const ctid = Number(advancedVars.var_ctid);
+        if (!Number.isInteger(ctid) || ctid < 100 || ctid > 999999999) {
+          newErrors.var_ctid = 'Must be an integer >= 100';
+        }
       }
     }
 
@@ -651,6 +660,22 @@ export function ConfigurationModal({
                       <option value={1}>Yes (Unprivileged)</option>
                       <option value={0}>No (Privileged)</option>
                     </select>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-foreground mb-2">
+                      CT/VM ID
+                    </label>
+                    <Input
+                      type="number"
+                      min="100"
+                      placeholder="Auto"
+                      value={typeof advancedVars.var_ctid === 'boolean' ? '' : (advancedVars.var_ctid ?? '')}
+                      onChange={(e) => updateAdvancedVar('var_ctid', e.target.value ? parseInt(e.target.value) : '')}
+                      className={errors.var_ctid ? 'border-destructive' : ''}
+                    />
+                    {errors.var_ctid && (
+                      <p className="mt-1 text-xs text-destructive">{errors.var_ctid}</p>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/app/_components/ConfigurationModal.tsx
+++ b/src/app/_components/ConfigurationModal.tsx
@@ -53,6 +53,13 @@ export function ConfigurationModal({
       { enabled: !!server?.id && isOpen && mode === "advanced" },
     );
 
+  // Fetch installation defaults (merged: server > global > null)
+  const { data: installDefaultsData } = api.installDefaults.getForServer.useQuery(
+    { serverId: server?.id ?? null },
+    { enabled: isOpen && mode === 'advanced' }
+  );
+  const installDefaults = installDefaultsData?.defaults as Record<string, string | number | null> | null | undefined;
+
   // Get resources from JSON
   const resources = actualScript?.install_methods?.[0]?.resources;
   const slug = actualScript?.slug ?? "";
@@ -74,6 +81,12 @@ export function ConfigurationModal({
   // Validation errors
   const [errors, setErrors] = useState<Record<string, string>>({});
 
+  // Helper: get install default or hardcoded fallback
+  const dflt = (key: string, hardcoded: string | number): string | number => {
+    const val = installDefaults?.[key];
+    return (val !== null && val !== undefined) ? val : hardcoded;
+  };
+
   // Initialize defaults when script/server data is available
   useEffect(() => {
     if (!actualScript || !server) return;
@@ -82,9 +95,10 @@ export function ConfigurationModal({
       // Default mode: minimal vars
       setContainerStorage("");
     } else {
-      // Advanced mode: all vars with defaults
+      // Advanced mode: merge Install Defaults > Hardcoded
+      // Resources always come from script metadata (never from install defaults)
       const defaults: EnvVars = {
-        // Resources from JSON
+        // Resources from JSON (not overridable by install defaults)
         var_cpu: resources?.cpu ?? 1,
         var_ram: resources?.ram ?? 1024,
         var_disk: resources?.hdd ?? 4,
@@ -95,48 +109,48 @@ export function ConfigurationModal({
               ? 0
               : 1,
 
-        // Network defaults
-        var_net: "dhcp",
-        var_brg: "vmbr0",
-        var_gateway: "",
-        var_ipv6_method: "none",
-        var_ipv6_static: "",
-        var_vlan: "",
-        var_mtu: 1500,
-        var_mac: "",
-        var_ns: "",
+        // Network defaults — install defaults > hardcoded
+        var_net: dflt('var_net_mode', 'dhcp') as string,
+        var_brg: dflt('var_brg', 'vmbr0') as string,
+        var_gateway: dflt('var_gateway', '') as string,
+        var_ipv6_method: dflt('var_ipv6_method', 'none') as string,
+        var_ipv6_static: '',
+        var_vlan: dflt('var_vlan', '') as string | number,
+        var_mtu: dflt('var_mtu', 1500) as number,
+        var_mac: '',
+        var_ns: dflt('var_ns', '') as string,
 
         // Identity
         var_hostname: slug,
-        var_pw: "",
-        var_tags: "community-script",
+        var_pw: dflt('var_pw', '') as string,
+        var_tags: dflt('var_tags', 'community-script') as string,
 
         // SSH
-        var_ssh: "no",
-        var_ssh_authorized_key: "",
+        var_ssh: dflt('var_ssh', 'no') as string,
+        var_ssh_authorized_key: dflt('var_ssh_authorized_key', '') as string,
 
         // Features
-        var_nesting: 1,
-        var_fuse: 0,
-        var_keyctl: 0,
+        var_nesting: dflt('var_nesting', 1) as number,
+        var_fuse: dflt('var_fuse', 0) as number,
+        var_keyctl: dflt('var_keyctl', 0) as number,
         var_mknod: 0,
-        var_mount_fs: "",
-        var_protection: "no",
-        var_tun: "no",
+        var_mount_fs: '',
+        var_protection: dflt('var_protection', 'no') as string,
+        var_tun: dflt('var_tun', 'no') as string,
 
         // System
-        var_timezone: "",
-        var_verbose: "no",
-        var_apt_cacher: "no",
-        var_apt_cacher_ip: "",
+        var_timezone: dflt('var_timezone', '') as string,
+        var_verbose: dflt('var_verbose', 'no') as string,
+        var_apt_cacher: dflt('var_apt_cacher', 'no') as string,
+        var_apt_cacher_ip: dflt('var_apt_cacher_ip', '') as string,
 
         // Storage
-        var_container_storage: "",
-        var_template_storage: "",
+        var_container_storage: dflt('var_container_storage', '') as string,
+        var_template_storage: dflt('var_template_storage', '') as string,
       };
       setAdvancedVars(defaults);
     }
-  }, [actualScript, server, mode, resources, slug]);
+  }, [actualScript, server, mode, resources, slug, installDefaults]);
 
   // Discover SSH keys on the Proxmox host when advanced mode is open
   useEffect(() => {

--- a/src/app/_components/GeneralSettingsModal.tsx
+++ b/src/app/_components/GeneralSettingsModal.tsx
@@ -2266,7 +2266,10 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
                 <select
                   value={bridges.some((bp: { name: string }) => bp.name === strVal("var_brg")) ? strVal("var_brg") : "__custom__"}
                   onChange={(e) => {
-                    if (e.target.value === "__custom__") return;
+                    if (e.target.value === "__custom__") {
+                      updateField("var_brg", "");
+                      return;
+                    }
                     handleBridgeSelect(e.target.value);
                   }}
                   className="border-input bg-background text-foreground focus:ring-ring mb-2 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"

--- a/src/app/_components/GeneralSettingsModal.tsx
+++ b/src/app/_components/GeneralSettingsModal.tsx
@@ -2262,11 +2262,14 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
               <label className="text-foreground mb-1 block text-sm">Bridge</label>
-              {bridges.length > 0 ? (
+              {bridges.length > 0 && (
                 <select
-                  value={strVal("var_brg") || ""}
-                  onChange={(e) => handleBridgeSelect(e.target.value)}
-                  className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                  value={bridges.some((bp: { name: string }) => bp.name === strVal("var_brg")) ? strVal("var_brg") : "__custom__"}
+                  onChange={(e) => {
+                    if (e.target.value === "__custom__") return;
+                    handleBridgeSelect(e.target.value);
+                  }}
+                  className="border-input bg-background text-foreground focus:ring-ring mb-2 w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
                 >
                   <option value="">— Not set —</option>
                   {bridges.map((bp: { id: number; name: string; gateway: string | null; nameserver: string | null }) => (
@@ -2274,8 +2277,10 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
                       {bp.name}{bp.gateway ? ` (GW: ${bp.gateway})` : ""}
                     </option>
                   ))}
+                  <option value="__custom__">Custom...</option>
                 </select>
-              ) : (
+              )}
+              {(bridges.length === 0 || !bridges.some((bp: { name: string }) => bp.name === strVal("var_brg"))) && (
                 <Input
                   type="text"
                   value={strVal("var_brg")}
@@ -2287,7 +2292,7 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
               )}
               {bridges.length > 0 && (
                 <p className="text-muted-foreground mt-1 text-xs">
-                  Selecting a bridge auto-fills Gateway and DNS.
+                  Select a profile or choose &quot;Custom&quot; to enter manually.
                 </p>
               )}
             </div>

--- a/src/app/_components/GeneralSettingsModal.tsx
+++ b/src/app/_components/GeneralSettingsModal.tsx
@@ -42,7 +42,7 @@ export function GeneralSettingsModal({
   const { theme, setTheme } = useTheme();
   const { isAuthenticated, expirationTime, checkAuth } = useAuth();
   const [activeTab, setActiveTab] = useState<
-    "general" | "github" | "auth" | "auto-sync" | "repositories"
+    "general" | "github" | "auth" | "auto-sync" | "repositories" | "defaults"
   >("general");
   const [sessionExpirationDisplay, setSessionExpirationDisplay] =
     useState<string>("");
@@ -746,6 +746,18 @@ export function GeneralSettingsModal({
               }`}
             >
               Repositories
+            </Button>
+            <Button
+              onClick={() => setActiveTab("defaults")}
+              variant="ghost"
+              size="null"
+              className={`w-full border-b-2 px-1 py-3 text-sm font-medium sm:w-auto sm:py-4 ${
+                activeTab === "defaults"
+                  ? "border-primary text-primary"
+                  : "text-muted-foreground hover:text-foreground hover:border-border border-transparent"
+              }`}
+            >
+              Defaults
             </Button>
           </nav>
         </div>
@@ -1867,7 +1879,482 @@ export function GeneralSettingsModal({
               </div>
             </div>
           )}
+
+          {activeTab === "defaults" && (
+            <DefaultsTabContent
+              message={message}
+              setMessage={setMessage}
+            />
+          )}
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Defaults Tab Component ──────────────────────────────────────────────────
+
+interface DefaultsTabContentProps {
+  message: { type: "success" | "error"; text: string } | null;
+  setMessage: (msg: { type: "success" | "error"; text: string } | null) => void;
+}
+
+function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
+  const [selectedServerId, setSelectedServerId] = useState<number | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Form state
+  const [formData, setFormData] = useState<Record<string, string | number | null>>({});
+
+  // Fetch servers list
+  const { data: serversData } = api.servers.getAllServers.useQuery();
+
+  // Fetch raw defaults for editing (no merging)
+  const { data: defaultsData, refetch: refetchDefaults } =
+    api.installDefaults.getByServerId.useQuery(
+      { serverId: selectedServerId },
+      { enabled: true }
+    );
+
+  // Upsert mutation
+  const upsertMutation = api.installDefaults.upsert.useMutation();
+  const deleteMutation = api.installDefaults.delete.useMutation();
+
+  // Load form data when defaults are fetched
+  useEffect(() => {
+    if (defaultsData?.defaults) {
+      const d = defaultsData.defaults;
+      setFormData({
+        var_brg: d.var_brg ?? null,
+        var_gateway: d.var_gateway ?? null,
+        var_ns: d.var_ns ?? null,
+        var_net_mode: d.var_net_mode ?? null,
+        var_vlan: d.var_vlan ?? null,
+        var_mtu: d.var_mtu ?? null,
+        var_ipv6_method: d.var_ipv6_method ?? null,
+        var_tags: d.var_tags ?? null,
+        var_pw: d.var_pw ?? null,
+        var_ssh: d.var_ssh ?? null,
+        var_ssh_authorized_key: d.var_ssh_authorized_key ?? null,
+        var_nesting: d.var_nesting ?? null,
+        var_fuse: d.var_fuse ?? null,
+        var_keyctl: d.var_keyctl ?? null,
+        var_tun: d.var_tun ?? null,
+        var_protection: d.var_protection ?? null,
+        var_timezone: d.var_timezone ?? null,
+        var_verbose: d.var_verbose ?? null,
+        var_apt_cacher: d.var_apt_cacher ?? null,
+        var_apt_cacher_ip: d.var_apt_cacher_ip ?? null,
+        var_container_storage: d.var_container_storage ?? null,
+        var_template_storage: d.var_template_storage ?? null,
+      });
+    } else {
+      setFormData({});
+    }
+  }, [defaultsData]);
+
+  const updateField = (key: string, value: string | number | null) => {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    setMessage(null);
+    try {
+      const result = await upsertMutation.mutateAsync({
+        serverId: selectedServerId,
+        name: selectedServerId === null ? "Global" : undefined,
+        ...formData,
+      } as Parameters<typeof upsertMutation.mutateAsync>[0]);
+
+      if (result.success) {
+        setMessage({ type: "success", text: "Installation defaults saved!" });
+        await refetchDefaults();
+      } else {
+        setMessage({ type: "error", text: result.error ?? "Failed to save defaults" });
+      }
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to save defaults",
+      });
+    } finally {
+      setIsSaving(false);
+      setTimeout(() => setMessage(null), 3000);
+    }
+  };
+
+  const handleReset = async () => {
+    setIsSaving(true);
+    setMessage(null);
+    try {
+      const result = await deleteMutation.mutateAsync({ serverId: selectedServerId });
+      if (result.success) {
+        setFormData({});
+        setMessage({ type: "success", text: "Defaults removed." });
+        await refetchDefaults();
+      } else {
+        setMessage({ type: "error", text: result.error ?? "Failed to remove defaults" });
+      }
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to remove defaults",
+      });
+    } finally {
+      setIsSaving(false);
+      setTimeout(() => setMessage(null), 3000);
+    }
+  };
+
+  const servers = serversData?.servers ?? [];
+  const strVal = (key: string) => (formData[key] as string) ?? "";
+  const numVal = (key: string) => formData[key] as number | null;
+
+  return (
+    <div className="space-y-4 sm:space-y-6">
+      <div>
+        <h3 className="text-foreground mb-3 text-base font-medium sm:mb-4 sm:text-lg">
+          Installation Defaults
+        </h3>
+        <p className="text-muted-foreground mb-4 text-sm sm:text-base">
+          Pre-fill Advanced Configuration fields when installing scripts.
+          Server-specific defaults override global defaults. Empty fields use
+          the hardcoded application defaults.
+        </p>
+
+        {/* Server Selector */}
+        <div className="border-border mb-4 rounded-lg border p-4">
+          <label className="text-foreground mb-2 block text-sm font-medium">
+            Apply defaults to
+          </label>
+          <select
+            value={selectedServerId === null ? "global" : String(selectedServerId)}
+            onChange={(e) => {
+              const val = e.target.value;
+              setSelectedServerId(val === "global" ? null : Number(val));
+            }}
+            className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+          >
+            <option value="global">Global (all servers)</option>
+            {servers.map((s: { id: number; name: string }) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          {selectedServerId !== null && (
+            <p className="text-muted-foreground mt-1 text-xs">
+              Server defaults override global defaults. Leave fields empty to
+              fall back to global.
+            </p>
+          )}
+        </div>
+
+        {/* Network Section */}
+        <div className="border-border mb-4 rounded-lg border p-4">
+          <h4 className="text-foreground mb-3 font-medium">Network</h4>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Bridge</label>
+              <Input
+                type="text"
+                value={strVal("var_brg")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_brg", e.target.value || null)
+                }
+                placeholder="vmbr0"
+              />
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Network Mode</label>
+              <select
+                value={strVal("var_net_mode") || ""}
+                onChange={(e) => updateField("var_net_mode", e.target.value || null)}
+                className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+              >
+                <option value="">— Not set —</option>
+                <option value="dhcp">DHCP</option>
+                <option value="static">Static</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Gateway</label>
+              <Input
+                type="text"
+                value={strVal("var_gateway")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_gateway", e.target.value || null)
+                }
+                placeholder="Auto"
+              />
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">DNS Nameserver</label>
+              <Input
+                type="text"
+                value={strVal("var_ns")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_ns", e.target.value || null)
+                }
+                placeholder="Auto"
+              />
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">VLAN</label>
+              <Input
+                type="text"
+                value={strVal("var_vlan")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_vlan", e.target.value || null)
+                }
+                placeholder="None"
+              />
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">MTU</label>
+              <Input
+                type="number"
+                value={numVal("var_mtu") ?? ""}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_mtu", e.target.value ? parseInt(e.target.value) : null)
+                }
+                placeholder="1500"
+              />
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">IPv6 Method</label>
+              <select
+                value={strVal("var_ipv6_method") || ""}
+                onChange={(e) => updateField("var_ipv6_method", e.target.value || null)}
+                className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+              >
+                <option value="">— Not set —</option>
+                <option value="none">None</option>
+                <option value="auto">Auto</option>
+                <option value="dhcp">DHCP</option>
+                <option value="static">Static</option>
+                <option value="disable">Disable</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {/* Identity Section */}
+        <div className="border-border mb-4 rounded-lg border p-4">
+          <h4 className="text-foreground mb-3 font-medium">Identity</h4>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Tags</label>
+              <Input
+                type="text"
+                value={strVal("var_tags")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_tags", e.target.value || null)
+                }
+                placeholder="community-script"
+              />
+              <p className="text-muted-foreground mt-1 text-xs">
+                Comma-separated tags
+              </p>
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Root Password</label>
+              <Input
+                type="password"
+                value={strVal("var_pw")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_pw", e.target.value || null)
+                }
+                placeholder="Empty = auto-login"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* SSH Section */}
+        <div className="border-border mb-4 rounded-lg border p-4">
+          <h4 className="text-foreground mb-3 font-medium">SSH Access</h4>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Enable SSH</label>
+              <select
+                value={strVal("var_ssh") || ""}
+                onChange={(e) => updateField("var_ssh", e.target.value || null)}
+                className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+              >
+                <option value="">— Not set —</option>
+                <option value="no">No</option>
+                <option value="yes">Yes</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">SSH Authorized Key</label>
+              <Input
+                type="text"
+                value={strVal("var_ssh_authorized_key")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_ssh_authorized_key", e.target.value || null)
+                }
+                placeholder="ssh-rsa AAAA..."
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Features Section */}
+        <div className="border-border mb-4 rounded-lg border p-4">
+          <h4 className="text-foreground mb-3 font-medium">Container Features</h4>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {[
+              { key: "var_nesting", label: "Nesting (Docker)", isInt: true },
+              { key: "var_fuse", label: "FUSE", isInt: true },
+              { key: "var_keyctl", label: "Keyctl", isInt: true },
+            ].map(({ key, label }) => (
+              <div key={key}>
+                <label className="text-foreground mb-1 block text-sm">{label}</label>
+                <select
+                  value={numVal(key) !== null && numVal(key) !== undefined ? String(numVal(key)) : ""}
+                  onChange={(e) =>
+                    updateField(key, e.target.value !== "" ? parseInt(e.target.value) : null)
+                  }
+                  className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                >
+                  <option value="">— Not set —</option>
+                  <option value="0">Disabled</option>
+                  <option value="1">Enabled</option>
+                </select>
+              </div>
+            ))}
+            {[
+              { key: "var_tun", label: "TUN/TAP (VPN)" },
+              { key: "var_protection", label: "Protection" },
+            ].map(({ key, label }) => (
+              <div key={key}>
+                <label className="text-foreground mb-1 block text-sm">{label}</label>
+                <select
+                  value={strVal(key) || ""}
+                  onChange={(e) => updateField(key, e.target.value || null)}
+                  className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                >
+                  <option value="">— Not set —</option>
+                  <option value="no">No</option>
+                  <option value="yes">Yes</option>
+                </select>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* System Section */}
+        <div className="border-border mb-4 rounded-lg border p-4">
+          <h4 className="text-foreground mb-3 font-medium">System Configuration</h4>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Timezone</label>
+              <Input
+                type="text"
+                value={strVal("var_timezone")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_timezone", e.target.value || null)
+                }
+                placeholder="System default"
+              />
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Verbose</label>
+              <select
+                value={strVal("var_verbose") || ""}
+                onChange={(e) => updateField("var_verbose", e.target.value || null)}
+                className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+              >
+                <option value="">— Not set —</option>
+                <option value="no">No</option>
+                <option value="yes">Yes</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">APT Cacher</label>
+              <select
+                value={strVal("var_apt_cacher") || ""}
+                onChange={(e) => updateField("var_apt_cacher", e.target.value || null)}
+                className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+              >
+                <option value="">— Not set —</option>
+                <option value="no">No</option>
+                <option value="yes">Yes</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">APT Cacher IP</label>
+              <Input
+                type="text"
+                value={strVal("var_apt_cacher_ip")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_apt_cacher_ip", e.target.value || null)
+                }
+                placeholder="192.168.1.10"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Storage Section */}
+        <div className="border-border mb-4 rounded-lg border p-4">
+          <h4 className="text-foreground mb-3 font-medium">Storage</h4>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Container Storage</label>
+              <Input
+                type="text"
+                value={strVal("var_container_storage")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_container_storage", e.target.value || null)
+                }
+                placeholder="Auto (e.g. local-zfs)"
+              />
+            </div>
+            <div>
+              <label className="text-foreground mb-1 block text-sm">Template Storage</label>
+              <Input
+                type="text"
+                value={strVal("var_template_storage")}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  updateField("var_template_storage", e.target.value || null)
+                }
+                placeholder="Auto (e.g. local)"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex gap-2">
+          <Button onClick={handleSave} disabled={isSaving} size="sm">
+            {isSaving ? "Saving..." : "Save Defaults"}
+          </Button>
+          <Button
+            onClick={handleReset}
+            disabled={isSaving}
+            variant="outline"
+            size="sm"
+          >
+            Reset to Empty
+          </Button>
+        </div>
+
+        {/* Message Display */}
+        {message && (
+          <div
+            className={`mt-4 rounded-md p-3 text-sm ${
+              message.type === "success"
+                ? "bg-success/10 text-success-foreground border-success/20 border"
+                : "bg-error/10 text-error-foreground border-error/20 border"
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/_components/GeneralSettingsModal.tsx
+++ b/src/app/_components/GeneralSettingsModal.tsx
@@ -2183,8 +2183,8 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
                           <span className="ml-1 text-xs text-muted-foreground">(global)</span>
                         )}
                       </td>
-                      <td className="px-3 py-2 text-muted-foreground">{bp.gateway || "—"}</td>
-                      <td className="px-3 py-2 text-muted-foreground">{bp.nameserver || "—"}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{bp.gateway ?? "—"}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{bp.nameserver ?? "—"}</td>
                       <td className="px-3 py-2 text-right">
                         <button
                           onClick={() => handleBridgeEdit(bp)}

--- a/src/app/_components/GeneralSettingsModal.tsx
+++ b/src/app/_components/GeneralSettingsModal.tsx
@@ -1906,6 +1906,13 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
   // Form state
   const [formData, setFormData] = useState<Record<string, string | number | null>>({});
 
+  // Bridge profile state
+  const [bridgeEditId, setBridgeEditId] = useState<number | null>(null);
+  const [bridgeName, setBridgeName] = useState("");
+  const [bridgeGateway, setBridgeGateway] = useState("");
+  const [bridgeNameserver, setBridgeNameserver] = useState("");
+  const [bridgeShowForm, setBridgeShowForm] = useState(false);
+
   // Fetch servers list
   const { data: serversData } = api.servers.getAllServers.useQuery();
 
@@ -1916,9 +1923,18 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
       { enabled: true }
     );
 
-  // Upsert mutation
+  // Fetch bridge profiles for selected server
+  const { data: bridgeData, refetch: refetchBridges } =
+    api.bridgeProfiles.getForServer.useQuery(
+      { serverId: selectedServerId },
+      { enabled: true }
+    );
+
+  // Mutations
   const upsertMutation = api.installDefaults.upsert.useMutation();
   const deleteMutation = api.installDefaults.delete.useMutation();
+  const bridgeUpsertMutation = api.bridgeProfiles.upsert.useMutation();
+  const bridgeDeleteMutation = api.bridgeProfiles.delete.useMutation();
 
   // Load form data when defaults are fetched
   useEffect(() => {
@@ -2007,7 +2023,82 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
     }
   };
 
+  // Bridge handlers
+  const resetBridgeForm = () => {
+    setBridgeEditId(null);
+    setBridgeName("");
+    setBridgeGateway("");
+    setBridgeNameserver("");
+    setBridgeShowForm(false);
+  };
+
+  const handleBridgeSave = async () => {
+    if (!bridgeName.trim()) return;
+    setMessage(null);
+    try {
+      const result = await bridgeUpsertMutation.mutateAsync({
+        id: bridgeEditId ?? undefined,
+        name: bridgeName.trim(),
+        gateway: bridgeGateway.trim() || null,
+        nameserver: bridgeNameserver.trim() || null,
+        serverId: selectedServerId,
+      });
+      if (result.success) {
+        setMessage({ type: "success", text: `Bridge "${bridgeName}" saved!` });
+        resetBridgeForm();
+        await refetchBridges();
+      } else {
+        setMessage({ type: "error", text: result.error ?? "Failed to save bridge" });
+      }
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to save bridge",
+      });
+    }
+    setTimeout(() => setMessage(null), 3000);
+  };
+
+  const handleBridgeDelete = async (id: number) => {
+    setMessage(null);
+    try {
+      const result = await bridgeDeleteMutation.mutateAsync({ id });
+      if (result.success) {
+        setMessage({ type: "success", text: "Bridge deleted." });
+        await refetchBridges();
+      } else {
+        setMessage({ type: "error", text: result.error ?? "Failed to delete bridge" });
+      }
+    } catch (error) {
+      setMessage({
+        type: "error",
+        text: error instanceof Error ? error.message : "Failed to delete bridge",
+      });
+    }
+    setTimeout(() => setMessage(null), 3000);
+  };
+
+  const handleBridgeEdit = (profile: { id: number; name: string; gateway: string | null; nameserver: string | null }) => {
+    setBridgeEditId(profile.id);
+    setBridgeName(profile.name);
+    setBridgeGateway(profile.gateway ?? "");
+    setBridgeNameserver(profile.nameserver ?? "");
+    setBridgeShowForm(true);
+  };
+
+  // When a bridge is selected in the dropdown, populate gateway and DNS
+  const handleBridgeSelect = (bridgeNameValue: string) => {
+    updateField("var_brg", bridgeNameValue || null);
+    const profiles = bridgeData?.profiles ?? [];
+    const match = profiles.find((p: { name: string }) => p.name === bridgeNameValue);
+    if (match) {
+      if (match.gateway) updateField("var_gateway", match.gateway);
+      if (match.nameserver) updateField("var_ns", match.nameserver);
+    }
+  };
+
   const servers = serversData?.servers ?? [];
+  const bridges = bridgeData?.profiles ?? [];
   const strVal = (key: string) => (formData[key] as string) ?? "";
   const numVal = (key: string) => formData[key] as number | null;
 
@@ -2051,20 +2142,154 @@ function DefaultsTabContent({ message, setMessage }: DefaultsTabContentProps) {
           )}
         </div>
 
+        {/* Bridge Profiles Section */}
+        <div className="border-border mb-4 rounded-lg border p-4">
+          <div className="mb-3 flex items-center justify-between">
+            <div>
+              <h4 className="text-foreground font-medium">Bridge Profiles</h4>
+              <p className="text-muted-foreground text-xs">
+                Define bridges with their gateway and DNS. Select a bridge below to auto-fill network settings.
+              </p>
+            </div>
+            {!bridgeShowForm && (
+              <Button
+                onClick={() => { resetBridgeForm(); setBridgeShowForm(true); }}
+                size="sm"
+                variant="outline"
+              >
+                + Add Bridge
+              </Button>
+            )}
+          </div>
+
+          {/* Bridge list */}
+          {bridges.length > 0 && (
+            <div className="mb-3 overflow-hidden rounded-md border border-border">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-border bg-muted/50">
+                    <th className="px-3 py-2 text-left font-medium text-foreground">Bridge</th>
+                    <th className="px-3 py-2 text-left font-medium text-foreground">Gateway</th>
+                    <th className="px-3 py-2 text-left font-medium text-foreground">DNS</th>
+                    <th className="px-3 py-2 text-right font-medium text-foreground">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {bridges.map((bp: { id: number; name: string; gateway: string | null; nameserver: string | null; server_id: number | null }) => (
+                    <tr key={bp.id} className="border-b border-border last:border-0">
+                      <td className="px-3 py-2 font-mono text-foreground">
+                        {bp.name}
+                        {bp.server_id === null && selectedServerId !== null && (
+                          <span className="ml-1 text-xs text-muted-foreground">(global)</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 text-muted-foreground">{bp.gateway || "—"}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{bp.nameserver || "—"}</td>
+                      <td className="px-3 py-2 text-right">
+                        <button
+                          onClick={() => handleBridgeEdit(bp)}
+                          className="mr-2 text-xs text-blue-500 hover:text-blue-700"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => handleBridgeDelete(bp.id)}
+                          className="text-xs text-red-500 hover:text-red-700"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {bridges.length === 0 && !bridgeShowForm && (
+            <p className="text-muted-foreground mb-3 text-sm">
+              No bridge profiles configured. Add a bridge to auto-fill gateway and DNS when selecting it.
+            </p>
+          )}
+
+          {/* Bridge add/edit form */}
+          {bridgeShowForm && (
+            <div className="rounded-md border border-border bg-muted/30 p-3">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+                <div>
+                  <label className="text-foreground mb-1 block text-xs font-medium">Bridge Name</label>
+                  <Input
+                    type="text"
+                    value={bridgeName}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBridgeName(e.target.value)}
+                    placeholder="vmbr0"
+                  />
+                </div>
+                <div>
+                  <label className="text-foreground mb-1 block text-xs font-medium">Gateway IP</label>
+                  <Input
+                    type="text"
+                    value={bridgeGateway}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBridgeGateway(e.target.value)}
+                    placeholder="10.0.10.254"
+                  />
+                </div>
+                <div>
+                  <label className="text-foreground mb-1 block text-xs font-medium">DNS Nameserver</label>
+                  <Input
+                    type="text"
+                    value={bridgeNameserver}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) => setBridgeNameserver(e.target.value)}
+                    placeholder="10.0.10.254"
+                  />
+                </div>
+              </div>
+              <div className="mt-3 flex gap-2">
+                <Button onClick={handleBridgeSave} size="sm" disabled={!bridgeName.trim()}>
+                  {bridgeEditId ? "Update" : "Add"} Bridge
+                </Button>
+                <Button onClick={resetBridgeForm} size="sm" variant="outline">
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+
         {/* Network Section */}
         <div className="border-border mb-4 rounded-lg border p-4">
           <h4 className="text-foreground mb-3 font-medium">Network</h4>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
               <label className="text-foreground mb-1 block text-sm">Bridge</label>
-              <Input
-                type="text"
-                value={strVal("var_brg")}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  updateField("var_brg", e.target.value || null)
-                }
-                placeholder="vmbr0"
-              />
+              {bridges.length > 0 ? (
+                <select
+                  value={strVal("var_brg") || ""}
+                  onChange={(e) => handleBridgeSelect(e.target.value)}
+                  className="border-input bg-background text-foreground focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2"
+                >
+                  <option value="">— Not set —</option>
+                  {bridges.map((bp: { id: number; name: string; gateway: string | null; nameserver: string | null }) => (
+                    <option key={bp.id} value={bp.name}>
+                      {bp.name}{bp.gateway ? ` (GW: ${bp.gateway})` : ""}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <Input
+                  type="text"
+                  value={strVal("var_brg")}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    updateField("var_brg", e.target.value || null)
+                  }
+                  placeholder="vmbr0"
+                />
+              )}
+              {bridges.length > 0 && (
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Selecting a bridge auto-fills Gateway and DNS.
+                </p>
+              )}
             </div>
             <div>
               <label className="text-foreground mb-1 block text-sm">Network Mode</label>

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -6,6 +6,7 @@ import { backupsRouter } from "~/server/api/routers/backups";
 import { pbsCredentialsRouter } from "~/server/api/routers/pbsCredentials";
 import { repositoriesRouter } from "~/server/api/routers/repositories";
 import { installDefaultsRouter } from "~/server/api/routers/installDefaults";
+import { bridgeProfilesRouter } from "~/server/api/routers/bridgeProfiles";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -22,6 +23,7 @@ export const appRouter = createTRPCRouter({
   pbsCredentials: pbsCredentialsRouter,
   repositories: repositoriesRouter,
   installDefaults: installDefaultsRouter,
+  bridgeProfiles: bridgeProfilesRouter,
 });
 
 // export type definition of API

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -5,6 +5,7 @@ import { versionRouter } from "~/server/api/routers/version";
 import { backupsRouter } from "~/server/api/routers/backups";
 import { pbsCredentialsRouter } from "~/server/api/routers/pbsCredentials";
 import { repositoriesRouter } from "~/server/api/routers/repositories";
+import { installDefaultsRouter } from "~/server/api/routers/installDefaults";
 import { createCallerFactory, createTRPCRouter } from "~/server/api/trpc";
 
 /**
@@ -20,6 +21,7 @@ export const appRouter = createTRPCRouter({
   backups: backupsRouter,
   pbsCredentials: pbsCredentialsRouter,
   repositories: repositoriesRouter,
+  installDefaults: installDefaultsRouter,
 });
 
 // export type definition of API

--- a/src/server/api/routers/bridgeProfiles.ts
+++ b/src/server/api/routers/bridgeProfiles.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import { prisma } from "~/server/db";
+
+const upsertSchema = z.object({
+  id: z.number().optional(),
+  name: z.string().min(1),
+  gateway: z.string().nullable(),
+  nameserver: z.string().nullable(),
+  serverId: z.number().nullable(),
+});
+
+export const bridgeProfilesRouter = createTRPCRouter({
+  // Get all bridge profiles
+  getAll: publicProcedure.query(async () => {
+    try {
+      const profiles = await prisma.bridgeProfile.findMany({
+        include: { server: { select: { id: true, name: true } } },
+        orderBy: [{ server_id: "asc" }, { name: "asc" }],
+      });
+      return { success: true, profiles };
+    } catch (error) {
+      console.error("Error fetching bridge profiles:", error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to fetch bridge profiles",
+        profiles: [],
+      };
+    }
+  }),
+
+  // Get bridge profiles for a specific server (server-specific + global)
+  getForServer: publicProcedure
+    .input(z.object({ serverId: z.number().nullable() }))
+    .query(async ({ input }) => {
+      try {
+        const where = input.serverId !== null
+          ? { OR: [{ server_id: null }, { server_id: input.serverId }] }
+          : { server_id: null };
+
+        const profiles = await prisma.bridgeProfile.findMany({
+          where,
+          orderBy: [{ name: "asc" }],
+        });
+
+        // Deduplicate: server-specific overrides global with same name
+        const byName = new Map<string, typeof profiles[0]>();
+        for (const p of profiles) {
+          const existing = byName.get(p.name);
+          if (!existing || (p.server_id !== null && existing.server_id === null)) {
+            byName.set(p.name, p);
+          }
+        }
+
+        return { success: true, profiles: Array.from(byName.values()) };
+      } catch (error) {
+        console.error("Error fetching bridge profiles for server:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to fetch bridge profiles",
+          profiles: [],
+        };
+      }
+    }),
+
+  // Create or update a bridge profile
+  upsert: publicProcedure
+    .input(upsertSchema)
+    .mutation(async ({ input }) => {
+      try {
+        const { id, name, gateway, nameserver, serverId } = input;
+
+        if (id) {
+          // Update existing
+          const result = await prisma.bridgeProfile.update({
+            where: { id },
+            data: { name, gateway, nameserver, server_id: serverId },
+          });
+          return { success: true, profile: result };
+        }
+
+        // Create new — check for duplicate name+server
+        const existing = await prisma.bridgeProfile.findFirst({
+          where: serverId === null
+            ? { name, server_id: null }
+            : { name, server_id: serverId },
+        });
+
+        if (existing) {
+          const result = await prisma.bridgeProfile.update({
+            where: { id: existing.id },
+            data: { gateway, nameserver },
+          });
+          return { success: true, profile: result };
+        }
+
+        const result = await prisma.bridgeProfile.create({
+          data: { name, gateway, nameserver, server_id: serverId },
+        });
+        return { success: true, profile: result };
+      } catch (error) {
+        console.error("Error upserting bridge profile:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to save bridge profile",
+        };
+      }
+    }),
+
+  // Delete a bridge profile
+  delete: publicProcedure
+    .input(z.object({ id: z.number() }))
+    .mutation(async ({ input }) => {
+      try {
+        await prisma.bridgeProfile.delete({ where: { id: input.id } });
+        return { success: true };
+      } catch (error) {
+        console.error("Error deleting bridge profile:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to delete bridge profile",
+        };
+      }
+    }),
+});

--- a/src/server/api/routers/installDefaults.ts
+++ b/src/server/api/routers/installDefaults.ts
@@ -109,7 +109,7 @@ export const installDefaultsRouter = createTRPCRouter({
         for (const key of Object.keys(installDefaultFields)) {
           const serverVal = (serverDefaults as Record<string, unknown>)[key];
           const globalVal = (globalDefaults as Record<string, unknown>)[key];
-          merged[key] = (serverVal !== null && serverVal !== undefined ? serverVal : globalVal) as string | number | null;
+          merged[key] = (serverVal ?? globalVal) as string | number | null;
         }
 
         return { success: true, defaults: merged };
@@ -171,7 +171,7 @@ export const installDefaultsRouter = createTRPCRouter({
             data: {
               ...data,
               server_id: serverId,
-              name: (name ?? (serverId === null ? "Global" : "Server Default")) as string,
+              name: name ?? (serverId === null ? "Global" : "Server Default"),
             },
           });
         }

--- a/src/server/api/routers/installDefaults.ts
+++ b/src/server/api/routers/installDefaults.ts
@@ -1,0 +1,212 @@
+import { z } from "zod";
+import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
+import { prisma } from "~/server/db";
+
+const installDefaultFields = {
+  var_brg: true,
+  var_gateway: true,
+  var_ns: true,
+  var_net_mode: true,
+  var_vlan: true,
+  var_mtu: true,
+  var_ipv6_method: true,
+  var_tags: true,
+  var_pw: true,
+  var_ssh: true,
+  var_ssh_authorized_key: true,
+  var_nesting: true,
+  var_fuse: true,
+  var_keyctl: true,
+  var_tun: true,
+  var_protection: true,
+  var_timezone: true,
+  var_verbose: true,
+  var_apt_cacher: true,
+  var_apt_cacher_ip: true,
+  var_container_storage: true,
+  var_template_storage: true,
+} as const;
+
+const upsertSchema = z.object({
+  serverId: z.number().nullable(),
+  name: z.string().optional(),
+  var_brg: z.string().nullable().optional(),
+  var_gateway: z.string().nullable().optional(),
+  var_ns: z.string().nullable().optional(),
+  var_net_mode: z.string().nullable().optional(),
+  var_vlan: z.string().nullable().optional(),
+  var_mtu: z.number().nullable().optional(),
+  var_ipv6_method: z.string().nullable().optional(),
+  var_tags: z.string().nullable().optional(),
+  var_pw: z.string().nullable().optional(),
+  var_ssh: z.string().nullable().optional(),
+  var_ssh_authorized_key: z.string().nullable().optional(),
+  var_nesting: z.number().nullable().optional(),
+  var_fuse: z.number().nullable().optional(),
+  var_keyctl: z.number().nullable().optional(),
+  var_tun: z.string().nullable().optional(),
+  var_protection: z.string().nullable().optional(),
+  var_timezone: z.string().nullable().optional(),
+  var_verbose: z.string().nullable().optional(),
+  var_apt_cacher: z.string().nullable().optional(),
+  var_apt_cacher_ip: z.string().nullable().optional(),
+  var_container_storage: z.string().nullable().optional(),
+  var_template_storage: z.string().nullable().optional(),
+});
+
+export const installDefaultsRouter = createTRPCRouter({
+  // Get all install defaults (global + per-server)
+  getAll: publicProcedure.query(async () => {
+    try {
+      const defaults = await prisma.installDefault.findMany({
+        include: { server: { select: { id: true, name: true } } },
+        orderBy: [{ server_id: "asc" }],
+      });
+      return { success: true, defaults };
+    } catch (error) {
+      console.error("Error fetching install defaults:", error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to fetch install defaults",
+        defaults: [],
+      };
+    }
+  }),
+
+  // Get merged defaults for a specific server (server > global > null)
+  getForServer: publicProcedure
+    .input(z.object({ serverId: z.number().nullable() }))
+    .query(async ({ input }) => {
+      try {
+        // Load global defaults (server_id IS NULL)
+        const globalDefaults = await prisma.installDefault.findFirst({
+          where: { server_id: null },
+          select: installDefaultFields,
+        });
+
+        // If no specific server requested, return global only
+        if (input.serverId === null) {
+          return { success: true, defaults: globalDefaults };
+        }
+
+        // Load server-specific defaults
+        const serverDefaults = await prisma.installDefault.findFirst({
+          where: { server_id: input.serverId },
+          select: installDefaultFields,
+        });
+
+        // Merge: server values override global values; null fields fall back to global
+        if (!serverDefaults) {
+          return { success: true, defaults: globalDefaults };
+        }
+
+        if (!globalDefaults) {
+          return { success: true, defaults: serverDefaults };
+        }
+
+        // Merge server over global — server non-null values take priority
+        const merged: Record<string, string | number | null> = {};
+        for (const key of Object.keys(installDefaultFields)) {
+          const serverVal = (serverDefaults as Record<string, unknown>)[key];
+          const globalVal = (globalDefaults as Record<string, unknown>)[key];
+          merged[key] = (serverVal !== null && serverVal !== undefined ? serverVal : globalVal) as string | number | null;
+        }
+
+        return { success: true, defaults: merged };
+      } catch (error) {
+        console.error("Error fetching install defaults for server:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to fetch install defaults",
+          defaults: null,
+        };
+      }
+    }),
+
+  // Get raw defaults for a specific server (no merging, for editing)
+  getByServerId: publicProcedure
+    .input(z.object({ serverId: z.number().nullable() }))
+    .query(async ({ input }) => {
+      try {
+        const defaults = await prisma.installDefault.findFirst({
+          where: input.serverId === null ? { server_id: null } : { server_id: input.serverId },
+        });
+        return { success: true, defaults };
+      } catch (error) {
+        console.error("Error fetching install defaults:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to fetch install defaults",
+          defaults: null,
+        };
+      }
+    }),
+
+  // Create or update install defaults
+  upsert: publicProcedure
+    .input(upsertSchema)
+    .mutation(async ({ input }) => {
+      try {
+        const { serverId, name, ...fields } = input;
+
+        // Convert undefined to null for all fields
+        const data: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(fields)) {
+          data[key] = value === undefined ? null : value;
+        }
+        if (name) data.name = name;
+
+        const existing = await prisma.installDefault.findFirst({
+          where: serverId === null ? { server_id: null } : { server_id: serverId },
+        });
+
+        let result;
+        if (existing) {
+          result = await prisma.installDefault.update({
+            where: { id: existing.id },
+            data,
+          });
+        } else {
+          result = await prisma.installDefault.create({
+            data: {
+              ...data,
+              server_id: serverId,
+              name: (name ?? (serverId === null ? "Global" : "Server Default")) as string,
+            },
+          });
+        }
+
+        return { success: true, defaults: result };
+      } catch (error) {
+        console.error("Error upserting install defaults:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to save install defaults",
+        };
+      }
+    }),
+
+  // Delete install defaults
+  delete: publicProcedure
+    .input(z.object({ serverId: z.number().nullable() }))
+    .mutation(async ({ input }) => {
+      try {
+        const existing = await prisma.installDefault.findFirst({
+          where: input.serverId === null ? { server_id: null } : { server_id: input.serverId },
+        });
+
+        if (!existing) {
+          return { success: false, error: "Install defaults not found" };
+        }
+
+        await prisma.installDefault.delete({ where: { id: existing.id } });
+        return { success: true };
+      } catch (error) {
+        console.error("Error deleting install defaults:", error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : "Failed to delete install defaults",
+        };
+      }
+    }),
+});


### PR DESCRIPTION
## Summary

Adds a new **Defaults** tab in Settings that allows users to pre-configure installation parameters on a global and per-server basis. This directly addresses **#91** — users no longer need to manually fill ~23 fields for every advanced installation.

### Features

- **Installation Defaults** — New Prisma model `InstallDefault` with 22 configurable fields (Network, Identity, SSH, Features, System, Storage). Supports global defaults and per-server overrides with automatic merge (Server > Global > Hardcoded).
- **Bridge Profiles** — New Prisma model `BridgeProfile` that auto-fills Gateway and DNS when a bridge is selected, reducing repetitive input for multi-network setups.
- **Optional CT/VM ID** — Adds an optional CT/VM ID field to advanced configuration for users who want to specify a specific ID.
- **build.func improvements** — Proper `-nameserver=` formatting for PVE API and tag deduplication to prevent duplicate `community-script` tags.

### Implementation

- **Backend:** Two new tRPC routers (`installDefaults`, `bridgeProfiles`) with full CRUD operations
- **UI:** New "Defaults" tab (6th tab) in GeneralSettingsModal with 6 setting groups. ConfigurationModal loads defaults via `getForServer` query with helper function `dflt(key, fallback)`.
- **Design choice:** Resources (CPU/RAM/Disk) are intentionally NOT overridable — they always come from script metadata to prevent misconfiguration.

### Screenshots

The Defaults tab provides a clean interface organized by category:

| Section | Fields |
|---------|--------|
| Network | Bridge, Gateway, DNS, Net Mode, VLAN, MTU |
| Identity | Password, Tags |
| SSH | SSH Enable, Authorized Key |
| Features | Nesting, FUSE, Keyctl, Protection, TUN |
| System | Timezone, Verbose, APT Cacher, APT Cacher IP |
| Storage | Container Storage, Template Storage |

Bridge profiles appear as a dropdown in the Configuration modal, with "Custom..." option for manual entry.

### Testing

- TypeScript: `tsc --noEmit` passes cleanly
- ESLint: 0 errors on all changed files
- Prisma: Schema generates successfully with new models
- Manually verified on a running instance (save, reload, defaults applied correctly)

Closes #91