### PR TITLE
fix: check for pve9.2

### DIFF
--- a/scripts/core/core.func
+++ b/scripts/core/core.func
@@ -301,7 +301,7 @@ root_check() {
 # pve_check()
 #
 # - Validates Proxmox VE version compatibility
-# - Supported: PVE 8.0-8.9 and PVE 9.0-9.1
+# - Supported: PVE 8.0-8.9 and PVE 9.0-9.2
 # - Exits with error message if unsupported version detected
 # ------------------------------------------------------------------------------
 pve_check() {
@@ -319,12 +319,12 @@ pve_check() {
 		return 0
 	fi
 
-	# Check for Proxmox VE 9.x: allow 9.0–9.1
+	# Check for Proxmox VE 9.x: allow 9.0–9.2
 	if [[ "$PVE_VER" =~ ^9\.([0-9]+) ]]; then
 		local MINOR="${BASH_REMATCH[1]}"
-		if ((MINOR < 0 || MINOR > 1)); then
+		if ((MINOR < 0 || MINOR > 2)); then
 			msg_error "This version of Proxmox VE is not yet supported."
-			msg_error "Supported: Proxmox VE version 9.0 – 9.1"
+			msg_error "Supported: Proxmox VE version 9.0 – 9.2"
 			exit 105
 		fi
 		return 0
@@ -332,7 +332,7 @@ pve_check() {
 
 	# All other unsupported versions
 	msg_error "This version of Proxmox VE is not supported."
-	msg_error "Supported versions: Proxmox VE 8.0 – 8.9 or 9.0 – 9.1"
+	msg_error "Supported versions: Proxmox VE 8.0 – 8.9 or 9.0 – 9.2"
 	exit 105
 }
 


### PR DESCRIPTION
<!--🛑 All Pull Requests need to made against the development branch. PRs against main will get closed. -->
## ✍️ Description  
Added support for Proxmox VE 9.2 to the `pve_check()` function. The version validation now accepts PVE 9.0 through 9.2 (previously 9.0 – 9.1), while the 8.x range (8.0 – 8.9) remains unchanged. Updated the header comment, the 9.x minor-version regex check, and both user-facing error messages to reflect the new supported range.

## 🔗 Related PR / Issue  
Fixes: #

## ✅ Prerequisites  (**X** in brackets) 
- [x] **Self-review completed** – Code follows project standards.  
- [x] **Tested thoroughly** – Changes work as expected.  
- [x] **No security risks** – No hardcoded secrets, unnecessary privilege escalations, or permission issues.  

## Screenshot for frontend Change
N/A – backend shell script change only.

---
## 🛠️ Type of Change (**X** in brackets)  
- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.  
- [ ] ✨ **New feature** – Adds new, non-breaking functionality.  
- [ ] 💥 **Breaking change** – Alters existing functionality in a way that may require updates.****