### PR TITLE
Several bugfixes, security hardening, and UX improvements

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,6 +38,14 @@ const OUTPUT_BUFFER_MAX_LENGTH = 1000;
 // Delay (ms) between backup completion and update start.
 const BACKUP_UPDATE_DELAY_MS = 1000;
 
+// Higher-contrast whiptail/dialog color scheme (default NEWT_COLORS is a
+// dark-blue-on-blue scheme that's hard to read once dialogs are properly
+// centered/sized). Exported into the remote shell before running
+// scripts/updates so whiptail/dialog UIs are actually legible. NEWT_COLORS
+// entries must be separated by real newlines (bash $'...' interprets \n),
+// not literal backslash-n.
+const NEWT_COLORS_EXPORT = `export NEWT_COLORS=$'root=,blue\\nborder=black,lightgray\\nwindow=black,lightgray\\nshadow=black,black\\ntitle=blue,lightgray\\nbutton=black,cyan\\nactbutton=white,blue\\ncheckbox=black,lightgray\\nactcheckbox=lightgray,blue\\nentry=black,lightgray\\nlabel=black,lightgray\\nlistbox=black,lightgray\\nactlistbox=black,cyan\\ntextbox=black,lightgray\\nacttextbox=black,cyan\\nhelpline=white,blue\\nroottext=black,lightgray';`;
+
 // Proxmox VMIDs are always purely numeric (typically 100-999999999).
 const CONTAINER_ID_PATTERN = /^\d+$/;
 // Proxmox storage identifiers only contain alphanumerics, underscore, hyphen, dot.
@@ -745,7 +753,7 @@ class ScriptExecutionHandler {
         .filter(([k]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(k))
         .map(([k, v]) => `export ${k}=${JSON.stringify(String(v))}`)
         .join('; ');
-      const envPrefix = envExports ? `${envExports}; ` : '';
+      const envPrefix = `${NEWT_COLORS_EXPORT} ${envExports ? `${envExports}; ` : ''}`;
 
       if (mode === 'ssh' && server) {
         // Transfer scripts folder to PVE host, then exec inside container
@@ -1799,11 +1807,7 @@ class ScriptExecutionHandler {
 
     // Send the update command after a delay to ensure we're in the container
     setTimeout(() => {
-      if (envExports) {
-        childProcess.write(`${envExports}; update\n`);
-      } else {
-        childProcess.write('update\n');
-      }
+      childProcess.write(`${NEWT_COLORS_EXPORT} ${envExports ? `${envExports}; ` : ''}update\n`);
     }, 4000);
 
     // Handle process exit
@@ -1903,11 +1907,7 @@ class ScriptExecutionHandler {
 
       // Send the update command after a delay to ensure we're in the container
       setTimeout(() => {
-        if (envExports) {
-          /** @type {any} */ (execution).process.write(`${envExports}; update\n`);
-        } else {
-          /** @type {any} */ (execution).process.write('update\n');
-        }
+        /** @type {any} */ (execution).process.write(`${NEWT_COLORS_EXPORT} ${envExports ? `${envExports}; ` : ''}update\n`);
       }, 4000);
 
     } catch (error) {
@@ -1985,7 +1985,13 @@ class ScriptExecutionHandler {
       });
     });
 
-    // Note: No automatic command is sent - user can type commands interactively
+    // Improve readability of any whiptail/dialog UI the user runs manually
+    // (LXC only — a VM's serial console may not have a shell ready yet).
+    if (containerType === 'lxc') {
+      setTimeout(() => {
+        childProcess.write(`${NEWT_COLORS_EXPORT}\n`);
+      }, 2000);
+    }
 
     // Handle process exit
     childProcess.onExit((e) => {
@@ -2050,7 +2056,13 @@ class ScriptExecutionHandler {
         ws
       });
 
-      // Note: No automatic command is sent - user can type commands interactively
+      // Improve readability of any whiptail/dialog UI the user runs manually
+      // (LXC only — a VM's serial console may not have a shell ready yet).
+      if (containerType === 'lxc') {
+        setTimeout(() => {
+          /** @type {any} */ (execution).process.write(`${NEWT_COLORS_EXPORT}\n`);
+        }, 2000);
+      }
 
     } catch (error) {
       this.sendMessage(ws, {

--- a/server.js
+++ b/server.js
@@ -463,18 +463,23 @@ class ScriptExecutionHandler {
             serverToUse = await this.resolveServerForSSH(serverToUse) ?? serverToUse;
           }
           const resolved = serverToUse ?? server;
+          // Fall back to reasonably large defaults if the client didn't report
+          // its actual terminal size — better than the old hardcoded 80x24/120x30
+          // which made whiptail/ncurses dialogs draw off-center in real usage.
+          const effectiveCols = typeof cols === 'number' && cols > 0 ? cols : 220;
+          const effectiveRows = typeof rows === 'number' && rows > 0 ? rows : 50;
           if (isClone && containerId && storage && server && cloneCount && hostnames && containerType) {
-            await this.startSSHCloneExecution(ws, containerId, executionId, storage, /** @type {ServerInfo} */(resolved), containerType, cloneCount, hostnames);
+            await this.startSSHCloneExecution(ws, containerId, executionId, storage, /** @type {ServerInfo} */(resolved), containerType, cloneCount, hostnames, effectiveCols, effectiveRows);
           } else if (isBackup && containerId && storage) {
-            await this.startBackupExecution(ws, containerId, executionId, storage, mode, resolved);
+            await this.startBackupExecution(ws, containerId, executionId, storage, mode, resolved, effectiveCols, effectiveRows);
           } else if (isUpdate && containerId) {
-            await this.startUpdateExecution(ws, containerId, executionId, mode, resolved, backupStorage, envVars, installedScriptId);
+            await this.startUpdateExecution(ws, containerId, executionId, mode, resolved, backupStorage, envVars, installedScriptId, effectiveCols, effectiveRows);
           } else if (isShell && containerId) {
-            await this.startShellExecution(ws, containerId, executionId, mode, resolved, containerType);
+            await this.startShellExecution(ws, containerId, executionId, mode, resolved, containerType, effectiveCols, effectiveRows);
           } else if (executeInContainer && containerId) {
-            await this.startInContainerScriptExecution(ws, scriptPath, executionId, mode, resolved, envVars, containerId, containerType ?? 'lxc');
+            await this.startInContainerScriptExecution(ws, scriptPath, executionId, mode, resolved, envVars, containerId, containerType ?? 'lxc', effectiveCols, effectiveRows);
           } else {
-            await this.startScriptExecution(ws, scriptPath, executionId, mode, resolved, envVars);
+            await this.startScriptExecution(ws, scriptPath, executionId, mode, resolved, envVars, effectiveCols, effectiveRows);
           }
         } else {
           this.sendMessage(ws, {
@@ -521,7 +526,7 @@ class ScriptExecutionHandler {
    * @param {ServerInfo|null} server
    * @param {Object} [envVars] - Optional environment variables to pass to the script
    */
-  async startScriptExecution(ws, scriptPath, executionId, mode = 'local', server = null, envVars = {}) {
+  async startScriptExecution(ws, scriptPath, executionId, mode = 'local', server = null, envVars = {}, cols = 220, rows = 50) {
     /** @type {number|null} */
     let installationId = null;
 
@@ -550,7 +555,7 @@ class ScriptExecutionHandler {
 
       // Handle SSH execution
       if (mode === 'ssh' && server) {
-        await this.startSSHScriptExecution(ws, scriptPath, executionId, server, installationId, envVars);
+        await this.startSSHScriptExecution(ws, scriptPath, executionId, server, installationId, envVars, cols, rows);
         return;
       }
 
@@ -599,8 +604,8 @@ class ScriptExecutionHandler {
       const childProcess = ptySpawn('bash', [resolvedPath], {
         cwd: scriptsDir,
         name: 'xterm-256color',
-        cols: 80,
-        rows: 24,
+        cols,
+        rows,
         env: envWithVars
       });
 
@@ -881,7 +886,7 @@ class ScriptExecutionHandler {
    * @param {number|null} installationId
    * @param {Object} [envVars] - Optional environment variables to pass to the script
    */
-  async startSSHScriptExecution(ws, scriptPath, executionId, server, installationId = null, envVars = {}) {
+  async startSSHScriptExecution(ws, scriptPath, executionId, server, installationId = null, envVars = {}, cols = 220, rows = 50) {
     const sshService = getSSHExecutionService();
 
     // Send start message

--- a/server.js
+++ b/server.js
@@ -38,6 +38,53 @@ const OUTPUT_BUFFER_MAX_LENGTH = 1000;
 // Delay (ms) between backup completion and update start.
 const BACKUP_UPDATE_DELAY_MS = 1000;
 
+// Proxmox VMIDs are always purely numeric (typically 100-999999999).
+const CONTAINER_ID_PATTERN = /^\d+$/;
+// Proxmox storage identifiers only contain alphanumerics, underscore, hyphen, dot.
+const STORAGE_ID_PATTERN = /^[a-zA-Z0-9_.-]+$/;
+// Conservative hostname pattern (labels of alphanumerics/hyphens, dot-separated).
+const HOSTNAME_PATTERN =
+  /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+const MAX_CLONE_COUNT = 50;
+
+/**
+ * Validate the subset of a WebSocket "start" message that ends up interpolated
+ * directly into shell commands executed on the Proxmox host (pct/qm/vzdump).
+ * These values normally come from trusted UI dropdowns/DB records, but the
+ * WebSocket endpoint itself has no other request-shape enforcement, so a
+ * malformed or malicious client could otherwise inject arbitrary shell syntax.
+ * @param {WebSocketMessage} message
+ * @returns {string | null} an error message if invalid, otherwise null
+ */
+function validateExecutionParams(message) {
+  const { containerId, storage, backupStorage, hostnames, containerType, cloneCount } = message;
+
+  if (containerId !== undefined && !CONTAINER_ID_PATTERN.test(String(containerId))) {
+    return `Invalid containerId: ${containerId}`;
+  }
+  if (storage !== undefined && !STORAGE_ID_PATTERN.test(String(storage))) {
+    return `Invalid storage identifier: ${storage}`;
+  }
+  if (backupStorage !== undefined && !STORAGE_ID_PATTERN.test(String(backupStorage))) {
+    return `Invalid backup storage identifier: ${backupStorage}`;
+  }
+  if (containerType !== undefined && containerType !== 'lxc' && containerType !== 'vm') {
+    return `Invalid containerType: ${containerType}`;
+  }
+  if (cloneCount !== undefined) {
+    const n = Number(cloneCount);
+    if (!Number.isInteger(n) || n < 1 || n > MAX_CLONE_COUNT) {
+      return `Invalid cloneCount: ${cloneCount}`;
+    }
+  }
+  if (hostnames !== undefined) {
+    if (!Array.isArray(hostnames) || !hostnames.every((h) => typeof h === 'string' && HOSTNAME_PATTERN.test(h))) {
+      return 'Invalid hostnames';
+    }
+  }
+  return null;
+}
+
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = '::';
 const port = parseInt(process.env.PORT || '3000', 10);
@@ -396,7 +443,16 @@ class ScriptExecutionHandler {
     const { action, scriptPath, executionId, input, mode, server, isUpdate, isShell, isBackup, isClone, executeInContainer, containerId, storage, backupStorage, cloneCount, hostnames, containerType, envVars, cols, rows } = message;
 
     switch (action) {
-      case 'start':
+      case 'start': {
+        const validationError = validateExecutionParams(message);
+        if (validationError) {
+          this.sendMessage(ws, {
+            type: 'error',
+            data: validationError,
+            timestamp: Date.now()
+          });
+          break;
+        }
         if (scriptPath && executionId) {
           let serverToUse = server;
           if (serverToUse?.id) {
@@ -424,6 +480,7 @@ class ScriptExecutionHandler {
           });
         }
         break;
+      }
 
       case 'stop':
         if (executionId) {
@@ -661,12 +718,22 @@ class ScriptExecutionHandler {
         return;
       }
 
+      // Guard against path traversal — every script must resolve inside the
+      // scripts directory, regardless of execution mode (local or SSH).
+      const scriptsDir = join(process.cwd(), 'scripts');
+      const resolvedScriptPath = resolve(scriptPath);
+      if (!resolvedScriptPath.startsWith(resolve(scriptsDir))) {
+        this.sendMessage(ws, { type: 'error', data: 'Script path outside scripts directory', timestamp: Date.now() });
+        return;
+      }
+
       const scriptName = scriptPath.split('/').pop() ?? scriptPath.split('\\').pop() ?? 'Unknown Script';
       const serverId = server ? (server.id ?? null) : null;
       installationId = await this.createInstallationRecord(scriptName, scriptPath, mode, serverId, containerId ?? null);
 
       // Build env-var export prefix
       const envExports = Object.entries(envVars ?? {})
+        .filter(([k]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(k))
         .map(([k, v]) => `export ${k}=${JSON.stringify(String(v))}`)
         .join('; ');
       const envPrefix = envExports ? `${envExports}; ` : '';
@@ -931,8 +998,17 @@ class ScriptExecutionHandler {
   stopScriptExecution(executionId) {
     const execution = this.activeExecutions.get(executionId);
     if (execution) {
-      execution.process.kill('SIGTERM');
+      execution.process?.kill('SIGTERM');
       this.activeExecutions.delete(executionId);
+
+      if (execution.installationId) {
+        this.updateInstallationRecord(execution.installationId, {
+          status: 'failed',
+          output_log: execution.outputBuffer
+        }).catch((error) => {
+          console.error('Error updating installation record after manual stop:', error);
+        });
+      }
 
       this.sendMessage(execution.ws, {
         type: 'end',
@@ -948,7 +1024,7 @@ class ScriptExecutionHandler {
    */
   sendInputToProcess(executionId, input) {
     const execution = this.activeExecutions.get(executionId);
-    if (execution && execution.process.write) {
+    if (execution?.process?.write) {
       execution.process.write(input);
     }
   }
@@ -1687,7 +1763,7 @@ class ScriptExecutionHandler {
 
     // Build env export commands (e.g. for PHS_SILENT=1)
     const envExports = Object.entries(envVars)
-      .filter(([key]) => key.startsWith('PHS_') || key.startsWith('var_'))
+      .filter(([key]) => (key.startsWith('PHS_') || key.startsWith('var_')) && /^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
       .map(([key, value]) => {
         const safeValue = String(value)
           .replace(/\\/g, '\\\\')
@@ -1767,7 +1843,7 @@ class ScriptExecutionHandler {
 
       // Build env export commands (e.g. for PHS_SILENT=1)
       const envExports = Object.entries(envVars)
-        .filter(([key]) => key.startsWith('PHS_') || key.startsWith('var_'))
+        .filter(([key]) => (key.startsWith('PHS_') || key.startsWith('var_')) && /^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
         .map(([key, value]) => {
           const safeValue = String(value)
             .replace(/\\/g, '\\\\')

--- a/server.js
+++ b/server.js
@@ -199,6 +199,7 @@ function isWebSocketUpgradeAuthorized(request) {
  * @property {Record<string, string|number|boolean>} [envVars]
  * @property {number} [cols]
  * @property {number} [rows]
+ * @property {number} [installedScriptId]
  */
 
 class ScriptExecutionHandler {
@@ -440,7 +441,7 @@ class ScriptExecutionHandler {
    * @param {WebSocketMessage} message
    */
   async handleMessage(ws, message) {
-    const { action, scriptPath, executionId, input, mode, server, isUpdate, isShell, isBackup, isClone, executeInContainer, containerId, storage, backupStorage, cloneCount, hostnames, containerType, envVars, cols, rows } = message;
+    const { action, scriptPath, executionId, input, mode, server, isUpdate, isShell, isBackup, isClone, executeInContainer, containerId, storage, backupStorage, cloneCount, hostnames, containerType, envVars, cols, rows, installedScriptId } = message;
 
     switch (action) {
       case 'start': {
@@ -464,7 +465,7 @@ class ScriptExecutionHandler {
           } else if (isBackup && containerId && storage) {
             await this.startBackupExecution(ws, containerId, executionId, storage, mode, resolved);
           } else if (isUpdate && containerId) {
-            await this.startUpdateExecution(ws, containerId, executionId, mode, resolved, backupStorage, envVars);
+            await this.startUpdateExecution(ws, containerId, executionId, mode, resolved, backupStorage, envVars, installedScriptId);
           } else if (isShell && containerId) {
             await this.startShellExecution(ws, containerId, executionId, mode, resolved, containerType);
           } else if (executeInContainer && containerId) {
@@ -720,9 +721,9 @@ class ScriptExecutionHandler {
 
       // Guard against path traversal — every script must resolve inside the
       // scripts directory, regardless of execution mode (local or SSH).
-      const scriptsDir = join(process.cwd(), 'scripts');
+      const guardScriptsDir = join(process.cwd(), 'scripts');
       const resolvedScriptPath = resolve(scriptPath);
-      if (!resolvedScriptPath.startsWith(resolve(scriptsDir))) {
+      if (!resolvedScriptPath.startsWith(resolve(guardScriptsDir))) {
         this.sendMessage(ws, { type: 'error', data: 'Script path outside scripts directory', timestamp: Date.now() });
         return;
       }
@@ -1652,8 +1653,9 @@ class ScriptExecutionHandler {
    * @param {string} mode
    * @param {ServerInfo|undefined} server
    * @param {string} [backupStorage] - Optional storage to backup to before update
+   * @param {number} [installedScriptId] - InstalledScript row to persist the final status/output to
    */
-  async startUpdateExecution(ws, containerId, executionId, mode = 'local', server = undefined, backupStorage = undefined, envVars = {}) {
+  async startUpdateExecution(ws, containerId, executionId, mode = 'local', server = undefined, backupStorage = undefined, envVars = {}, installedScriptId = undefined) {
     try {
       // If backup storage is provided, run backup first
       if (backupStorage && mode === 'ssh' && server) {
@@ -1714,9 +1716,9 @@ class ScriptExecutionHandler {
       });
 
       if (mode === 'ssh' && server) {
-        await this.startSSHUpdateExecution(ws, containerId, executionId, server, envVars);
+        await this.startSSHUpdateExecution(ws, containerId, executionId, server, envVars, installedScriptId);
       } else {
-        await this.startLocalUpdateExecution(ws, containerId, executionId, envVars);
+        await this.startLocalUpdateExecution(ws, containerId, executionId, envVars, installedScriptId);
       }
 
     } catch (error) {
@@ -1733,8 +1735,10 @@ class ScriptExecutionHandler {
    * @param {ExtendedWebSocket} ws
    * @param {string} containerId
    * @param {string} executionId
+   * @param {Object} [envVars]
+   * @param {number} [installedScriptId]
    */
-  async startLocalUpdateExecution(ws, containerId, executionId, envVars = {}) {
+  async startLocalUpdateExecution(ws, containerId, executionId, envVars = {}, installedScriptId = undefined) {
     const { spawn } = await import('node-pty');
 
     // Create a shell process that will run pct enter and then update
@@ -1749,11 +1753,15 @@ class ScriptExecutionHandler {
     // Store the execution
     this.activeExecutions.set(executionId, {
       process: childProcess,
-      ws
+      ws,
+      installationId: installedScriptId ?? null,
+      outputBuffer: ''
     });
 
     // Handle pty data
     childProcess.onData((data) => {
+      const execution = this.activeExecutions.get(executionId);
+      if (execution) execution.outputBuffer += data.toString();
       this.sendMessage(ws, {
         type: 'output',
         data: data.toString(),
@@ -1782,7 +1790,15 @@ class ScriptExecutionHandler {
     }, 4000);
 
     // Handle process exit
-    childProcess.onExit((e) => {
+    childProcess.onExit(async (e) => {
+      const execution = this.activeExecutions.get(executionId);
+      if (installedScriptId && execution) {
+        await this.updateInstallationRecord(installedScriptId, {
+          status: e.exitCode === 0 ? 'success' : 'failed',
+          output_log: execution.outputBuffer
+        });
+      }
+
       this.sendMessage(ws, {
         type: 'end',
         data: `Update completed with exit code: ${e.exitCode}`,
@@ -1799,8 +1815,10 @@ class ScriptExecutionHandler {
    * @param {string} containerId
    * @param {string} executionId
    * @param {ServerInfo} server
+   * @param {Object} [envVars]
+   * @param {number} [installedScriptId]
    */
-  async startSSHUpdateExecution(ws, containerId, executionId, server, envVars = {}) {
+  async startSSHUpdateExecution(ws, containerId, executionId, server, envVars = {}, installedScriptId = undefined) {
     const sshService = getSSHExecutionService();
 
     try {
@@ -1809,6 +1827,8 @@ class ScriptExecutionHandler {
         `pct enter ${containerId}`,
         /** @param {string} data */
         (data) => {
+          const activeExec = this.activeExecutions.get(executionId);
+          if (activeExec) activeExec.outputBuffer += data;
           this.sendMessage(ws, {
             type: 'output',
             data: data,
@@ -1824,7 +1844,15 @@ class ScriptExecutionHandler {
           });
         },
         /** @param {number} code */
-        (code) => {
+        async (code) => {
+          const activeExec = this.activeExecutions.get(executionId);
+          if (installedScriptId && activeExec) {
+            await this.updateInstallationRecord(installedScriptId, {
+              status: code === 0 ? 'success' : 'failed',
+              output_log: activeExec.outputBuffer
+            });
+          }
+
           this.sendMessage(ws, {
             type: 'end',
             data: `Update completed with exit code: ${code}`,
@@ -1838,7 +1866,9 @@ class ScriptExecutionHandler {
       // Store the execution
       this.activeExecutions.set(executionId, {
         process: /** @type {any} */ (execution).process,
-        ws
+        ws,
+        installationId: installedScriptId ?? null,
+        outputBuffer: ''
       });
 
       // Build env export commands (e.g. for PHS_SILENT=1)

--- a/server.js
+++ b/server.js
@@ -718,7 +718,7 @@ class ScriptExecutionHandler {
    * @param {string} containerId
    * @param {'lxc'|'vm'} containerType
    */
-  async startInContainerScriptExecution(ws, scriptPath, executionId, mode = 'local', server = null, envVars = {}, containerId, containerType = 'lxc') {
+  async startInContainerScriptExecution(ws, scriptPath, executionId, mode = 'local', server = null, envVars = {}, containerId, containerType = 'lxc', cols = 220, rows = 50) {
     /** @type {number|null} */
     let installationId = null;
     try {
@@ -816,7 +816,9 @@ class ScriptExecutionHandler {
             }
             this.sendMessage(ws, { type: 'end', data: `Finished with code: ${exitCode}`, timestamp: Date.now() });
             this.activeExecutions.delete(executionId);
-          }
+          },
+          cols,
+          rows
         );
 
         // Attach the real PTY process so keyboard input can reach interactive prompts
@@ -845,8 +847,8 @@ class ScriptExecutionHandler {
       const childProcess = ptySpawn(cmd, args, {
         cwd: scriptsDir,
         name: 'xterm-256color',
-        cols: 80,
-        rows: 24,
+        cols,
+        rows,
         env: { ...process.env, TERM: 'xterm-256color' }
       });
 
@@ -976,7 +978,9 @@ class ScriptExecutionHandler {
           // Clean up
           this.activeExecutions.delete(executionId);
         },
-        envVars
+        envVars,
+        cols,
+        rows
       ));
 
       // Store the execution with installation ID
@@ -1094,7 +1098,7 @@ class ScriptExecutionHandler {
    * @param {string} mode
    * @param {ServerInfo|null} server
    */
-  async startBackupExecution(ws, containerId, executionId, storage, mode = 'local', server = null) {
+  async startBackupExecution(ws, containerId, executionId, storage, mode = 'local', server = null, cols = 220, rows = 50) {
     try {
       // Send start message
       this.sendMessage(ws, {
@@ -1104,7 +1108,7 @@ class ScriptExecutionHandler {
       });
 
       if (mode === 'ssh' && server) {
-        await this.startSSHBackupExecution(ws, containerId, executionId, storage, server);
+        await this.startSSHBackupExecution(ws, containerId, executionId, storage, server, undefined, cols, rows);
       } else {
         this.sendMessage(ws, {
           type: 'error',
@@ -1130,7 +1134,7 @@ class ScriptExecutionHandler {
    * @param {ServerInfo} server
    * @param {Function} [onComplete] - Optional callback when backup completes
    */
-  startSSHBackupExecution(ws, containerId, executionId, storage, server, onComplete = undefined) {
+  startSSHBackupExecution(ws, containerId, executionId, storage, server, onComplete = undefined, cols = 220, rows = 50) {
     const sshService = getSSHExecutionService();
 
     return new Promise((resolve, reject) => {
@@ -1201,7 +1205,9 @@ class ScriptExecutionHandler {
             }
 
             this.activeExecutions.delete(executionId);
-          }
+          },
+          cols,
+          rows
         ).then((execution) => {
           // Store the execution
           this.activeExecutions.set(executionId, {
@@ -1248,7 +1254,7 @@ class ScriptExecutionHandler {
    * @param {number} cloneCount
    * @param {string[]} hostnames
    */
-  async startSSHCloneExecution(ws, containerId, executionId, storage, server, containerType, cloneCount, hostnames) {
+  async startSSHCloneExecution(ws, containerId, executionId, storage, server, containerType, cloneCount, hostnames, cols = 220, rows = 50) {
     const sshService = getSSHExecutionService();
 
     this.sendMessage(ws, {
@@ -1663,7 +1669,7 @@ class ScriptExecutionHandler {
    * @param {string} [backupStorage] - Optional storage to backup to before update
    * @param {number} [installedScriptId] - InstalledScript row to persist the final status/output to
    */
-  async startUpdateExecution(ws, containerId, executionId, mode = 'local', server = undefined, backupStorage = undefined, envVars = {}, installedScriptId = undefined) {
+  async startUpdateExecution(ws, containerId, executionId, mode = 'local', server = undefined, backupStorage = undefined, envVars = {}, installedScriptId = undefined, cols = 220, rows = 50) {
     try {
       // If backup storage is provided, run backup first
       if (backupStorage && mode === 'ssh' && server) {
@@ -1683,7 +1689,10 @@ class ScriptExecutionHandler {
             containerId,
             backupExecutionId,
             backupStorage,
-            server
+            server,
+            undefined,
+            cols,
+            rows
           );
 
           // Backup completed (successfully or not)
@@ -1724,9 +1733,9 @@ class ScriptExecutionHandler {
       });
 
       if (mode === 'ssh' && server) {
-        await this.startSSHUpdateExecution(ws, containerId, executionId, server, envVars, installedScriptId);
+        await this.startSSHUpdateExecution(ws, containerId, executionId, server, envVars, installedScriptId, cols, rows);
       } else {
-        await this.startLocalUpdateExecution(ws, containerId, executionId, envVars, installedScriptId);
+        await this.startLocalUpdateExecution(ws, containerId, executionId, envVars, installedScriptId, cols, rows);
       }
 
     } catch (error) {
@@ -1746,14 +1755,14 @@ class ScriptExecutionHandler {
    * @param {Object} [envVars]
    * @param {number} [installedScriptId]
    */
-  async startLocalUpdateExecution(ws, containerId, executionId, envVars = {}, installedScriptId = undefined) {
+  async startLocalUpdateExecution(ws, containerId, executionId, envVars = {}, installedScriptId = undefined, cols = 220, rows = 50) {
     const { spawn } = await import('node-pty');
 
     // Create a shell process that will run pct enter and then update
     const childProcess = spawn('bash', ['-c', `pct enter ${containerId}`], {
       name: 'xterm-color',
-      cols: 80,
-      rows: 24,
+      cols,
+      rows,
       cwd: process.cwd(),
       env: process.env
     });
@@ -1826,7 +1835,7 @@ class ScriptExecutionHandler {
    * @param {Object} [envVars]
    * @param {number} [installedScriptId]
    */
-  async startSSHUpdateExecution(ws, containerId, executionId, server, envVars = {}, installedScriptId = undefined) {
+  async startSSHUpdateExecution(ws, containerId, executionId, server, envVars = {}, installedScriptId = undefined, cols = 220, rows = 50) {
     const sshService = getSSHExecutionService();
 
     try {
@@ -1868,7 +1877,9 @@ class ScriptExecutionHandler {
           });
 
           this.activeExecutions.delete(executionId);
-        }
+        },
+        cols,
+        rows
       );
 
       // Store the execution
@@ -1917,7 +1928,7 @@ class ScriptExecutionHandler {
    * @param {ServerInfo|null} server
    * @param {'lxc'|'vm'} [containerType='lxc']
    */
-  async startShellExecution(ws, containerId, executionId, mode = 'local', server = null, containerType = 'lxc') {
+  async startShellExecution(ws, containerId, executionId, mode = 'local', server = null, containerType = 'lxc', cols = 220, rows = 50) {
     try {
       const typeLabel = containerType === 'vm' ? 'VM' : 'container';
       this.sendMessage(ws, {
@@ -1927,9 +1938,9 @@ class ScriptExecutionHandler {
       });
 
       if (mode === 'ssh' && server) {
-        await this.startSSHShellExecution(ws, containerId, executionId, server, containerType);
+        await this.startSSHShellExecution(ws, containerId, executionId, server, containerType, cols, rows);
       } else {
-        await this.startLocalShellExecution(ws, containerId, executionId, containerType);
+        await this.startLocalShellExecution(ws, containerId, executionId, containerType, cols, rows);
       }
 
     } catch (error) {
@@ -1948,13 +1959,13 @@ class ScriptExecutionHandler {
    * @param {string} executionId
    * @param {'lxc'|'vm'} [containerType='lxc']
    */
-  async startLocalShellExecution(ws, containerId, executionId, containerType = 'lxc') {
+  async startLocalShellExecution(ws, containerId, executionId, containerType = 'lxc', cols = 220, rows = 50) {
     const { spawn } = await import('node-pty');
     const shellCommand = containerType === 'vm' ? `qm terminal ${containerId}` : `pct enter ${containerId}`;
     const childProcess = spawn('bash', ['-c', shellCommand], {
       name: 'xterm-color',
-      cols: 80,
-      rows: 24,
+      cols,
+      rows,
       cwd: process.cwd(),
       env: process.env
     });
@@ -1996,7 +2007,7 @@ class ScriptExecutionHandler {
    * @param {ServerInfo} server
    * @param {'lxc'|'vm'} [containerType='lxc']
    */
-  async startSSHShellExecution(ws, containerId, executionId, server, containerType = 'lxc') {
+  async startSSHShellExecution(ws, containerId, executionId, server, containerType = 'lxc', cols = 220, rows = 50) {
     const sshService = getSSHExecutionService();
     const shellCommand = containerType === 'vm' ? `qm terminal ${containerId}` : `pct enter ${containerId}`;
     try {
@@ -2028,7 +2039,9 @@ class ScriptExecutionHandler {
           });
 
           this.activeExecutions.delete(executionId);
-        }
+        },
+        cols,
+        rows
       );
 
       // Store the execution

--- a/server.js
+++ b/server.js
@@ -267,8 +267,9 @@ class ScriptExecutionHandler {
       /Container\s*(\d+)\s*is\s*ready/i,
       /Container\s*(\d+)\s*started/i,
 
-      // Generic number patterns that might be container IDs (3-4 digits)
-      /(?:^|\s)(\d{3,4})(?:\s|$)/m,
+      // Deliberately no generic bare-number fallback here: a stray 3-4 digit
+      // number in unrelated output (port, percentage, byte count) would be
+      // misdetected as the container ID and could overwrite a correct one.
     ];
 
     // Try patterns on both original and cleaned output
@@ -310,8 +311,10 @@ class ScriptExecutionHandler {
       /https?:\/\/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d+)\//gi,
       // URLs with just IP and port (no protocol)
       /(?:^|\s)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}):(\d+)(?:\s|$)/gi,
-      // URLs with just IP (no protocol, no port)
-      /(?:^|\s)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})(?:\s|$)/gi,
+
+      // Deliberately no bare-IP-only fallback (no protocol, no port): a
+      // netmask, DNS resolver IP, or unrelated dotted-quad printed by the
+      // script would be misdetected as the web UI address.
     ];
 
     // Try patterns on both original and cleaned output

--- a/src/app/_components/BackupsTab.tsx
+++ b/src/app/_components/BackupsTab.tsx
@@ -26,6 +26,7 @@ import {
 import { ConfirmationModal } from "./ConfirmationModal";
 import { LoadingModal } from "./LoadingModal";
 import { useShell } from "./ShellContext";
+import { useRegisterModal } from "./modal/ModalStackProvider";
 import type { Server as ServerType } from "~/types/server";
 
 interface Backup {
@@ -75,6 +76,11 @@ export function BackupsTab() {
     containerIds: string[]; // multi-select
   } | null>(null);
   const [selectedStorage, setSelectedStorage] = useState("");
+  const createDialogZIndex = useRegisterModal(!!createDialog, {
+    id: "backups-create-dialog",
+    allowEscape: true,
+    onClose: () => setCreateDialog(null),
+  });
 
   const {
     data: backupsData,
@@ -730,7 +736,10 @@ export function BackupsTab() {
                   : "Select Containers";
 
           return createPortal(
-            <div className="fixed inset-0 z-[10000] overflow-y-auto bg-black/45 backdrop-blur-sm">
+            <div
+              className="fixed inset-0 overflow-y-auto bg-black/45 backdrop-blur-sm"
+              style={{ zIndex: createDialogZIndex }}
+            >
               <div className="flex min-h-full items-start justify-center p-4 pt-12 pb-8">
                 <div className="bg-card border-border w-full max-w-3xl rounded-2xl border shadow-2xl">
                   {/* Header */}

--- a/src/app/_components/DiffViewer.tsx
+++ b/src/app/_components/DiffViewer.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { api } from "~/trpc/react";
+import { useRegisterModal, ModalPortal } from "./modal/ModalStackProvider";
 
 interface DiffViewerProps {
   scriptSlug: string;
@@ -16,6 +17,11 @@ export function DiffViewer({
   isOpen,
   onClose,
 }: DiffViewerProps) {
+  const zIndex = useRegisterModal(isOpen, {
+    id: "diff-viewer",
+    allowEscape: true,
+    onClose,
+  });
   const [isLoading, setIsLoading] = useState(false);
 
   // Get diff content
@@ -74,10 +80,12 @@ export function DiffViewer({
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
-      onClick={handleBackdropClick}
-    >
+    <ModalPortal>
+      <div
+        className="fixed inset-0 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+        style={{ zIndex }}
+        onClick={handleBackdropClick}
+      >
       <div className="bg-card border-border mx-4 max-h-[90vh] w-full max-w-6xl overflow-hidden rounded-lg border shadow-xl sm:mx-0">
         {/* Header */}
         <div className="border-border flex items-center justify-between border-b p-4">
@@ -191,6 +199,7 @@ export function DiffViewer({
           )}
         </div>
       </div>
-    </div>
+      </div>
+    </ModalPortal>
   );
 }

--- a/src/app/_components/FloatingShell.tsx
+++ b/src/app/_components/FloatingShell.tsx
@@ -145,6 +145,7 @@ function FloatingShellWindow({
         hostnames: session.terminal!.hostnames,
         containerType: session.terminal!.containerType,
         envVars: session.terminal!.envVars,
+        onScriptEnd: session.autoCloseOnEnd ? onClose : undefined,
       }
     : isBackupTask
       ? {

--- a/src/app/_components/FloatingShell.tsx
+++ b/src/app/_components/FloatingShell.tsx
@@ -146,6 +146,7 @@ function FloatingShellWindow({
         containerType: session.terminal!.containerType,
         envVars: session.terminal!.envVars,
         onScriptEnd: session.autoCloseOnEnd ? onClose : undefined,
+        installedScriptId: session.terminal!.installedScriptId,
       }
     : isBackupTask
       ? {

--- a/src/app/_components/GeneratorTab.tsx
+++ b/src/app/_components/GeneratorTab.tsx
@@ -30,6 +30,7 @@ import type { Script } from "~/types/script";
 import type { Server } from "~/types/server";
 import { api } from "~/trpc/react";
 import { useShell } from "./ShellContext";
+import { useRegisterModal } from "./modal/ModalStackProvider";
 
 /* ── Step definitions ── */
 const CPU_STEPS = Array.from({ length: 16 }, (_, i) => i + 1);
@@ -181,6 +182,11 @@ export function GeneratorTab() {
         : null,
     [downloadDialogSlug, scriptCardsData],
   );
+  const downloadDialogZIndex = useRegisterModal(!!downloadDialogSlug, {
+    id: "generator-download-dialog",
+    allowEscape: true,
+    onClose: () => setDownloadDialogSlug(null),
+  });
 
   // Script selection
   const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
@@ -1791,7 +1797,8 @@ export function GeneratorTab() {
         downloadDialogScript &&
         createPortal(
           <div
-            className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 backdrop-blur-sm"
+            className="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+            style={{ zIndex: downloadDialogZIndex }}
             onClick={() => setDownloadDialogSlug(null)}
           >
             <div

--- a/src/app/_components/InstalledScriptsTab.tsx
+++ b/src/app/_components/InstalledScriptsTab.tsx
@@ -112,6 +112,7 @@ export function InstalledScriptsTab() {
     containerType?: "lxc" | "vm";
     storage?: string;
     envVars?: Record<string, string>;
+    isBatchUpdate?: boolean;
   } | null>(null);
   const [openingShell, _setOpeningShellUnused] = useState<null>(null); // replaced by ShellContext — kept to avoid refactoring refs below
   const setOpeningShell = (
@@ -1068,6 +1069,7 @@ export function InstalledScriptsTab() {
       server,
       isBackupOnly: false,
       envVars: { PHS_SILENT: "1" },
+      isBatchUpdate: true,
     });
   };
 
@@ -1371,6 +1373,8 @@ export function InstalledScriptsTab() {
           : `Update CT ${updatingScript.containerId}`,
       containerId: updatingScript.containerId,
       containerType: updatingScript.containerType ?? "lxc",
+      startMinimized: updatingScript.isBatchUpdate,
+      autoCloseOnEnd: updatingScript.isBatchUpdate,
       terminal: {
         scriptPath,
         mode: updatingScript.server ? "ssh" : "local",

--- a/src/app/_components/InstalledScriptsTab.tsx
+++ b/src/app/_components/InstalledScriptsTab.tsx
@@ -159,6 +159,10 @@ export function InstalledScriptsTab() {
   );
   const [batchUpdateIndex, setBatchUpdateIndex] = useState(0);
   const [isBatchUpdating, setIsBatchUpdating] = useState(false);
+  const [batchUpdateSummary, setBatchUpdateSummary] = useState<{
+    succeeded: { name: string; containerId: string }[];
+    failed: { name: string; containerId: string }[];
+  } | null>(null);
   const [editingScriptId, setEditingScriptId] = useState<number | null>(null);
   const [editFormData, setEditFormData] = useState<{
     script_name: string;
@@ -1049,11 +1053,31 @@ export function InstalledScriptsTab() {
         setBatchUpdateIndex(nextIndex);
         startBatchUpdateFor(batchUpdateQueue[nextIndex]!);
       } else {
-        // Batch complete
+        // Batch complete — refetch, then report which containers actually
+        // succeeded/failed instead of silently moving on either way.
         setIsBatchUpdating(false);
         setBatchUpdateQueue([]);
         setBatchUpdateIndex(0);
-        void refetchScripts();
+        void refetchScripts().then((result) => {
+          const freshScripts =
+            (result.data?.scripts as InstalledScript[] | undefined) ?? [];
+          const freshById = new Map(freshScripts.map((s) => [s.id, s]));
+          const succeeded: { name: string; containerId: string }[] = [];
+          const failed: { name: string; containerId: string }[] = [];
+          for (const queued of batchUpdateQueue) {
+            const fresh = freshById.get(queued.id);
+            const entry = {
+              name: queued.script_name,
+              containerId: queued.container_id ?? "?",
+            };
+            if (fresh?.status === "failed") {
+              failed.push(entry);
+            } else {
+              succeeded.push(entry);
+            }
+          }
+          setBatchUpdateSummary({ succeeded, failed });
+        });
       }
     }
   };
@@ -1397,6 +1421,12 @@ export function InstalledScriptsTab() {
             ? updatingScript.backupStorage
             : undefined,
         envVars: updatingScript.envVars,
+        // Only a plain update maps 1:1 onto this InstalledScript row — clone
+        // creates new rows, and backup-only doesn't touch this one's status.
+        installedScriptId:
+          !updatingScript.isBackupOnly && !updatingScript.isClone
+            ? updatingScript.id
+            : undefined,
       },
       onComplete: handleCloseUpdateTerminal,
     });
@@ -1586,6 +1616,40 @@ export function InstalledScriptsTab() {
   return (
     <div className="space-y-6">
       {/* Shell Terminal — now rendered as FloatingShell dialog (see ShellContext) */}
+
+      {batchUpdateSummary && (
+        <div
+          className={`rounded-lg border p-4 ${
+            batchUpdateSummary.failed.length > 0
+              ? "border-destructive/40 bg-destructive/10"
+              : "border-success/40 bg-success/10"
+          }`}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-foreground font-medium">
+                Batch update complete: {batchUpdateSummary.succeeded.length}{" "}
+                succeeded, {batchUpdateSummary.failed.length} failed
+              </p>
+              {batchUpdateSummary.failed.length > 0 && (
+                <p className="text-muted-foreground mt-1 text-sm">
+                  Failed:{" "}
+                  {batchUpdateSummary.failed
+                    .map((f) => `${f.name} (CT ${f.containerId})`)
+                    .join(", ")}
+                </p>
+              )}
+            </div>
+            <Button
+              onClick={() => setBatchUpdateSummary(null)}
+              variant="outline"
+              size="sm"
+            >
+              Dismiss
+            </Button>
+          </div>
+        </div>
+      )}
 
       {/* Header with Stats */}
       <div className="bg-card border-border rounded-lg border p-6 shadow-sm">

--- a/src/app/_components/InstalledScriptsTab.tsx
+++ b/src/app/_components/InstalledScriptsTab.tsx
@@ -13,7 +13,7 @@ import { LXCSettingsModal } from "./LXCSettingsModal";
 import { StorageSelectionModal } from "./StorageSelectionModal";
 import { BackupWarningModal } from "./BackupWarningModal";
 import { CloneCountInputModal } from "./CloneCountInputModal";
-import { ModalPortal } from "./modal/ModalStackProvider";
+import { ModalPortal, useRegisterModal } from "./modal/ModalStackProvider";
 import type { Storage } from "~/server/services/storageService";
 import type { Server } from "~/types/server";
 import { useShell } from "./ShellContext";
@@ -135,6 +135,14 @@ export function InstalledScriptsTab() {
   const [showStorageSelection, setShowStorageSelection] = useState(false);
   const [pendingUpdateScript, setPendingUpdateScript] =
     useState<InstalledScript | null>(null);
+  const backupPromptZIndex = useRegisterModal(showBackupPrompt, {
+    id: "backup-prompt-modal",
+    allowEscape: true,
+    onClose: () => {
+      setShowBackupPrompt(false);
+      setPendingUpdateScript(null);
+    },
+  });
   const [backupStorages, setBackupStorages] = useState<Storage[]>([]);
   const [isLoadingStorages, setIsLoadingStorages] = useState(false);
   const [showBackupWarning, setShowBackupWarning] = useState(false);
@@ -2540,7 +2548,10 @@ export function InstalledScriptsTab() {
       {/* Backup Prompt Modal */}
       {showBackupPrompt && (
         <ModalPortal>
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm">
+          <div
+            className="fixed inset-0 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+            style={{ zIndex: backupPromptZIndex }}
+          >
             <div className="bg-card border-border w-full max-w-md rounded-lg border shadow-xl">
               <div className="border-border flex items-center justify-center border-b p-6">
                 <div className="flex items-center gap-3">

--- a/src/app/_components/ServerForm.tsx
+++ b/src/app/_components/ServerForm.tsx
@@ -417,6 +417,18 @@ export function ServerForm({
               </div>
             </div>
           )}
+
+          {!colorCodingEnabled && (
+            <div>
+              <label className="text-muted-foreground mb-1 block text-sm font-medium">
+                Server Color
+              </label>
+              <p className="text-muted-foreground text-xs">
+                Disabled — enable it under Settings → General → &quot;Server
+                Color Coding&quot; to assign a color to this server.
+              </p>
+            </div>
+          )}
         </div>
 
         {/* Password Authentication */}

--- a/src/app/_components/SettingsModal.tsx
+++ b/src/app/_components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import { ServerList } from "./ServerList";
 import { Button } from "./ui/button";
 import { ContextualHelpIcon } from "./ContextualHelpIcon";
 import { useRegisterModal, ModalPortal } from "./modal/ModalStackProvider";
+import { useToast } from "./ToastContext";
 import { X } from "lucide-react";
 
 interface SettingsModalProps {
@@ -23,6 +24,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [servers, setServers] = useState<Server[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { toast } = useToast();
 
   useEffect(() => {
     if (isOpen) {
@@ -62,12 +64,17 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       });
 
       if (!response.ok) {
-        throw new Error("Failed to create server");
+        const body = await response.json().catch(() => null);
+        throw new Error(body?.error ?? "Failed to create server");
       }
 
       await fetchServers();
+      toast(`Server "${serverData.name}" added successfully`, "success");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create server");
+      const message =
+        err instanceof Error ? err.message : "Failed to create server";
+      setError(message);
+      toast(message, "error");
     }
   };
 
@@ -85,28 +92,39 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       });
 
       if (!response.ok) {
-        throw new Error("Failed to update server");
+        const body = await response.json().catch(() => null);
+        throw new Error(body?.error ?? "Failed to update server");
       }
 
       await fetchServers();
+      toast(`Server "${serverData.name}" updated successfully`, "success");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update server");
+      const message =
+        err instanceof Error ? err.message : "Failed to update server";
+      setError(message);
+      toast(message, "error");
     }
   };
 
   const handleDeleteServer = async (id: number) => {
+    const serverName = servers.find((s) => s.id === id)?.name ?? "Server";
     try {
       const response = await fetch(`/api/servers/${id}`, {
         method: "DELETE",
       });
 
       if (!response.ok) {
-        throw new Error("Failed to delete server");
+        const body = await response.json().catch(() => null);
+        throw new Error(body?.error ?? "Failed to delete server");
       }
 
       await fetchServers();
+      toast(`"${serverName}" deleted`, "success");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to delete server");
+      const message =
+        err instanceof Error ? err.message : "Failed to delete server";
+      setError(message);
+      toast(message, "error");
     }
   };
 

--- a/src/app/_components/ShellContext.tsx
+++ b/src/app/_components/ShellContext.tsx
@@ -40,6 +40,7 @@ export interface ShellSession {
     hostnames?: string[];
     containerType?: "lxc" | "vm";
     envVars?: Record<string, string | number | boolean>;
+    installedScriptId?: number;
   };
   /** Callback fired when the terminal closes (e.g. to trigger re-discovery). */
   onComplete?: () => void;

--- a/src/app/_components/ShellContext.tsx
+++ b/src/app/_components/ShellContext.tsx
@@ -43,6 +43,12 @@ export interface ShellSession {
   };
   /** Callback fired when the terminal closes (e.g. to trigger re-discovery). */
   onComplete?: () => void;
+  /** Open this session minimized instead of as a focused floating window
+   *  (e.g. for unattended batch tasks that shouldn't demand attention). */
+  startMinimized?: boolean;
+  /** Automatically close the window once the script reports completion,
+   *  instead of requiring the user to close it manually. */
+  autoCloseOnEnd?: boolean;
 }
 
 export interface ShellEntry {
@@ -82,7 +88,10 @@ export function ShellProvider({ children }: { children: React.ReactNode }) {
         );
       }
       const id = `session_${Date.now()}_${Math.random().toString(36).substr(2, 6)}`;
-      return [...prev, { id, session: s, state: "open" }];
+      return [
+        ...prev,
+        { id, session: s, state: s.startMinimized ? "minimized" : "open" },
+      ];
     });
   }, []);
 

--- a/src/app/_components/Terminal.tsx
+++ b/src/app/_components/Terminal.tsx
@@ -44,6 +44,9 @@ interface TerminalProps {
   envVars?: Record<string, string | number | boolean>;
   /** Called when the script/process reports it has finished (WS "end" message). */
   onScriptEnd?: () => void;
+  /** InstalledScript row this update applies to — lets the backend persist
+   *  the update's final status/output instead of only showing it live. */
+  installedScriptId?: number;
 }
 
 interface TerminalMessage {
@@ -218,6 +221,7 @@ export function Terminal({
   containerType,
   envVars,
   onScriptEnd,
+  installedScriptId,
 }: TerminalProps) {
   const [isConnected, setIsConnected] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
@@ -664,6 +668,7 @@ export function Terminal({
               hostnames,
               containerType,
               envVars,
+              installedScriptId,
               cols: xtermRef.current?.cols ?? 120,
               rows: xtermRef.current?.rows ?? 30,
             };
@@ -750,6 +755,7 @@ export function Terminal({
           cloneCount,
           hostnames,
           containerType,
+          installedScriptId,
           cols: xtermRef.current?.cols ?? 220,
           rows: xtermRef.current?.rows ?? 50,
         }),

--- a/src/app/_components/Terminal.tsx
+++ b/src/app/_components/Terminal.tsx
@@ -42,6 +42,8 @@ interface TerminalProps {
   hostnames?: string[];
   containerType?: "lxc" | "vm";
   envVars?: Record<string, string | number | boolean>;
+  /** Called when the script/process reports it has finished (WS "end" message). */
+  onScriptEnd?: () => void;
 }
 
 interface TerminalMessage {
@@ -215,6 +217,7 @@ export function Terminal({
   hostnames,
   containerType,
   envVars,
+  onScriptEnd,
 }: TerminalProps) {
   const [isConnected, setIsConnected] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
@@ -345,10 +348,11 @@ export function Terminal({
           } else {
             xtermRef.current.writeln(`${prefix}✅ ${message.data}`);
           }
+          onScriptEnd?.();
           break;
       }
     },
-    [scriptPath, containerId, scriptName],
+    [scriptPath, containerId, scriptName, onScriptEnd],
   );
 
   // Ensure we're on the client side

--- a/src/app/_components/ToastContext.tsx
+++ b/src/app/_components/ToastContext.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { CheckCircle2, XCircle, Info, X } from "lucide-react";
+
+export type ToastVariant = "success" | "error" | "info";
+
+interface ToastEntry {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  toast: (message: string, variant?: ToastVariant) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const DEFAULT_DURATION_MS = 4000;
+const ERROR_DURATION_MS = 6000;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [entries, setEntries] = useState<ToastEntry[]>([]);
+
+  const dismiss = useCallback((id: string) => {
+    setEntries((prev) => prev.filter((e) => e.id !== id));
+  }, []);
+
+  const toast = useCallback(
+    (message: string, variant: ToastVariant = "info") => {
+      const id = `toast_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      setEntries((prev) => [...prev, { id, message, variant }]);
+      setTimeout(
+        () => dismiss(id),
+        variant === "error" ? ERROR_DURATION_MS : DEFAULT_DURATION_MS,
+      );
+    },
+    [dismiss],
+  );
+
+  const value = useMemo(() => ({ toast }), [toast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <ToastViewport entries={entries} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+function ToastViewport({
+  entries,
+  onDismiss,
+}: {
+  entries: ToastEntry[];
+  onDismiss: (id: string) => void;
+}) {
+  const [mounted, setMounted] = useState(false);
+  useState(() => setMounted(true));
+  if (!mounted || entries.length === 0) return null;
+
+  return createPortal(
+    <div className="fixed right-4 bottom-4 z-[300] flex w-full max-w-sm flex-col gap-2">
+      {entries.map((entry) => (
+        <ToastCard key={entry.id} entry={entry} onDismiss={onDismiss} />
+      ))}
+    </div>,
+    document.body,
+  );
+}
+
+function ToastCard({
+  entry,
+  onDismiss,
+}: {
+  entry: ToastEntry;
+  onDismiss: (id: string) => void;
+}) {
+  const styles: Record<ToastVariant, { border: string; icon: React.ReactNode }> = {
+    success: {
+      border: "border-success/40 bg-success/10",
+      icon: <CheckCircle2 className="text-success h-5 w-5 shrink-0" />,
+    },
+    error: {
+      border: "border-destructive/40 bg-destructive/10",
+      icon: <XCircle className="text-destructive h-5 w-5 shrink-0" />,
+    },
+    info: {
+      border: "border-info/40 bg-info/10",
+      icon: <Info className="text-info h-5 w-5 shrink-0" />,
+    },
+  };
+  const style = styles[entry.variant];
+
+  return (
+    <div
+      className={`bg-card text-foreground flex items-start gap-3 rounded-lg border p-3 shadow-lg ${style.border}`}
+    >
+      {style.icon}
+      <p className="flex-1 text-sm">{entry.message}</p>
+      <button
+        onClick={() => onDismiss(entry.id)}
+        className="text-muted-foreground hover:text-foreground shrink-0"
+        aria-label="Dismiss"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,7 @@ import { api } from "~/trpc/react";
 import { useAuth } from "./_components/AuthProvider";
 import { ShellProvider } from "./_components/ShellContext";
 import { FloatingShell } from "./_components/FloatingShell";
+import { ToastProvider } from "./_components/ToastContext";
 import type { ScriptCard } from "~/types/script";
 
 // Lazy load heavy tab components — only the active tab is loaded
@@ -443,9 +444,11 @@ function Home() {
 
 export default function HomeWithShell() {
   return (
-    <ShellProvider>
-      <Home />
-      <FloatingShell />
-    </ShellProvider>
+    <ToastProvider>
+      <ShellProvider>
+        <Home />
+        <FloatingShell />
+      </ShellProvider>
+    </ToastProvider>
   );
 }

--- a/src/server/api/routers/installedScripts.ts
+++ b/src/server/api/routers/installedScripts.ts
@@ -652,10 +652,12 @@ export const installedScriptsRouter = createTRPCRouter({
             server_name: script.server?.name ?? null,
             server_ip: script.server?.ip ?? null,
             server_user: script.server?.user ?? null,
-            server_password: script.server?.password ?? null,
+            // Credentials are intentionally never sent to the client — SSH
+            // execution always re-resolves them server-side by server_id.
+            server_password: null,
             server_auth_type: script.server?.auth_type ?? null,
-            server_ssh_key: script.server?.ssh_key ?? null,
-            server_ssh_key_passphrase: script.server?.ssh_key_passphrase ?? null,
+            server_ssh_key: null,
+            server_ssh_key_passphrase: null,
             server_ssh_port: script.server?.ssh_port ?? null,
             server_color: script.server?.color ?? null,
             is_vm,
@@ -713,10 +715,12 @@ export const installedScriptsRouter = createTRPCRouter({
             server_name: script.server?.name ?? null,
             server_ip: script.server?.ip ?? null,
             server_user: script.server?.user ?? null,
-            server_password: script.server?.password ?? null,
+            // Credentials are intentionally never sent to the client — SSH
+            // execution always re-resolves them server-side by server_id.
+            server_password: null,
             server_auth_type: script.server?.auth_type ?? null,
-            server_ssh_key: script.server?.ssh_key ?? null,
-            server_ssh_key_passphrase: script.server?.ssh_key_passphrase ?? null,
+            server_ssh_key: null,
+            server_ssh_key_passphrase: null,
             server_ssh_port: script.server?.ssh_port ?? null,
             server_color: script.server?.color ?? null,
             is_vm,
@@ -764,10 +768,12 @@ export const installedScriptsRouter = createTRPCRouter({
           server_name: script.server?.name ?? null,
           server_ip: script.server?.ip ?? null,
           server_user: script.server?.user ?? null,
-          server_password: script.server?.password ?? null,
+          // Credentials are intentionally never sent to the client — SSH
+          // execution always re-resolves them server-side by server_id.
+          server_password: null,
           server_auth_type: script.server?.auth_type ?? null,
-          server_ssh_key: script.server?.ssh_key ?? null,
-          server_ssh_key_passphrase: script.server?.ssh_key_passphrase ?? null,
+          server_ssh_key: null,
+          server_ssh_key_passphrase: null,
           server_ssh_port: script.server?.ssh_port ?? null,
           server_color: script.server?.color ?? null,
           is_vm,

--- a/src/server/api/routers/servers.ts
+++ b/src/server/api/routers/servers.ts
@@ -4,9 +4,14 @@ import { getDatabase } from "~/server/database-prisma";
 import type { Server } from "~/types/server";
 
 /** Strip SSH/password secrets before a server record leaves the backend. */
-function redactServer<T extends Partial<Server>>(
-  server: T,
-): Omit<T, "password" | "ssh_key" | "ssh_key_passphrase" | "ssh_key_path"> {
+function redactServer<
+  T extends {
+    password?: string | null;
+    ssh_key?: string | null;
+    ssh_key_passphrase?: string | null;
+    ssh_key_path?: string | null;
+  },
+>(server: T) {
   const { password: _password, ssh_key: _sshKey, ssh_key_passphrase: _sshKeyPassphrase, ssh_key_path: _sshKeyPath, ...safeServer } = server;
   return safeServer;
 }

--- a/src/server/api/routers/servers.ts
+++ b/src/server/api/routers/servers.ts
@@ -3,13 +3,21 @@ import { createTRPCRouter, publicProcedure } from "~/server/api/trpc";
 import { getDatabase } from "~/server/database-prisma";
 import type { Server } from "~/types/server";
 
+/** Strip SSH/password secrets before a server record leaves the backend. */
+function redactServer<T extends Partial<Server>>(
+  server: T,
+): Omit<T, "password" | "ssh_key" | "ssh_key_passphrase" | "ssh_key_path"> {
+  const { password: _password, ssh_key: _sshKey, ssh_key_passphrase: _sshKeyPassphrase, ssh_key_path: _sshKeyPath, ...safeServer } = server;
+  return safeServer;
+}
+
 export const serversRouter = createTRPCRouter({
   getAllServers: publicProcedure
     .query(async () => {
       try {
         const db = getDatabase();
         const servers = await db.getAllServers();
-        return { success: true, servers };
+        return { success: true, servers: servers.map(redactServer) };
       } catch (error) {
         console.error('Error fetching servers:', error);
         return {
@@ -29,7 +37,7 @@ export const serversRouter = createTRPCRouter({
         if (!server) {
           return { success: false, error: 'Server not found', server: null };
         }
-        return { success: true, server };
+        return { success: true, server: redactServer(server) };
       } catch (error) {
         console.error('Error fetching server:', error);
         return {

--- a/src/server/services/scriptDownloader.js
+++ b/src/server/services/scriptDownloader.js
@@ -420,7 +420,24 @@ export class ScriptDownloaderService {
    * @returns {Promise<boolean>}
    */
   async isScriptDownloaded(script) {
-    if (!script.install_methods?.length) return false;
+    if (!script.install_methods?.length) {
+      // No install methods on record (common for PocketBase "pve"/"addon" tool
+      // scripts) — fall back to the type-derived path used by loadScript's own
+      // fallback download, instead of always reporting "not downloaded".
+      const fallbackScriptPath = this.deriveScriptPath(script.type, 'default', script.slug);
+      if (!fallbackScriptPath) return false;
+      const fallbackFileName = fallbackScriptPath.split('/').pop();
+      const fallbackSubDir = fallbackScriptPath.includes('/')
+        ? fallbackScriptPath.substring(0, fallbackScriptPath.lastIndexOf('/'))
+        : '';
+      const fallbackPath = join(this.scriptsDirectory, fallbackSubDir, fallbackFileName);
+      try {
+        await import('fs/promises').then(fs => fs.readFile(fallbackPath, 'utf8'));
+        return true;
+      } catch {
+        return false;
+      }
+    }
 
     // Check if ALL script files are downloaded
     for (const method of script.install_methods) {
@@ -531,19 +548,26 @@ export class ScriptDownloaderService {
         }
       }
 
-      // Fallback: if install_methods is empty but this is a CT/LXC script,
-      // still check for the main CT script file (may have been downloaded via fallback)
+      // Fallback: if install_methods is empty, still check for the main script
+      // file at its type-derived path (may have been downloaded via loadScript's
+      // own fallback path, which applies to every type, not just CT/LXC).
       const chkTypeNorm = (script.type || 'ct').toLowerCase();
       const hasCtScript = chkTypeNorm === 'ct' || chkTypeNorm === 'lxc';
-      if ((!script.install_methods || script.install_methods.length === 0) && hasCtScript) {
-        const fallbackFileName = `${script.slug}.sh`;
-        const fallbackPath = join(this.scriptsDirectory, 'ct', fallbackFileName);
-        try {
-          await access(fallbackPath);
-          files.push(`ct/${fallbackFileName}`);
-          ctExists = true;
-        } catch {
-          // File doesn't exist
+      if (!script.install_methods || script.install_methods.length === 0) {
+        const fallbackScriptPath = this.deriveScriptPath(script.type, 'default', script.slug);
+        if (fallbackScriptPath) {
+          const fallbackFileName = fallbackScriptPath.split('/').pop();
+          const fallbackSubDir = fallbackScriptPath.includes('/')
+            ? fallbackScriptPath.substring(0, fallbackScriptPath.lastIndexOf('/'))
+            : '';
+          const fallbackPath = join(this.scriptsDirectory, fallbackSubDir, fallbackFileName);
+          try {
+            await access(fallbackPath);
+            files.push(fallbackScriptPath);
+            ctExists = true;
+          } catch {
+            // File doesn't exist
+          }
         }
       }
 

--- a/src/server/services/scriptDownloader.js
+++ b/src/server/services/scriptDownloader.js
@@ -425,8 +425,8 @@ export class ScriptDownloaderService {
       // scripts) — fall back to the type-derived path used by loadScript's own
       // fallback download, instead of always reporting "not downloaded".
       const fallbackScriptPath = this.deriveScriptPath(script.type, 'default', script.slug);
-      if (!fallbackScriptPath) return false;
-      const fallbackFileName = fallbackScriptPath.split('/').pop();
+      const fallbackFileName = fallbackScriptPath?.split('/').pop();
+      if (!fallbackScriptPath || !fallbackFileName) return false;
       const fallbackSubDir = fallbackScriptPath.includes('/')
         ? fallbackScriptPath.substring(0, fallbackScriptPath.lastIndexOf('/'))
         : '';
@@ -555,8 +555,8 @@ export class ScriptDownloaderService {
       const hasCtScript = chkTypeNorm === 'ct' || chkTypeNorm === 'lxc';
       if (!script.install_methods || script.install_methods.length === 0) {
         const fallbackScriptPath = this.deriveScriptPath(script.type, 'default', script.slug);
-        if (fallbackScriptPath) {
-          const fallbackFileName = fallbackScriptPath.split('/').pop();
+        const fallbackFileName = fallbackScriptPath?.split('/').pop();
+        if (fallbackScriptPath && fallbackFileName) {
           const fallbackSubDir = fallbackScriptPath.includes('/')
             ? fallbackScriptPath.substring(0, fallbackScriptPath.lastIndexOf('/'))
             : '';

--- a/src/server/ssh-execution-service.js
+++ b/src/server/ssh-execution-service.js
@@ -110,8 +110,12 @@ class SSHExecutionService {
           // Build SSH command based on authentication type
           const { command, args } = this.buildSSHCommand(server, cols, rows);
 
-          // Format environment variables as var_name=value pairs
+          // Format environment variables as var_name=value pairs. Keys are
+          // interpolated unescaped, so only allow safe shell identifier
+          // characters through — anything else is dropped rather than risking
+          // shell-syntax injection via a malformed variable name.
           const envVarsString = Object.entries(envVars)
+            .filter(([key]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
             .map(([key, value]) => {
               // Escape special characters in values
               const escapedValue = String(value).replace(/'/g, "'\\''");
@@ -128,21 +132,19 @@ class SSHExecutionService {
             scriptCommand += ` && bash ${relativeScriptPath}`;
           }
 
-          // Log the full command that will be executed
+          // Log execution metadata WITHOUT variable values or the full
+          // interpolated command — envVars can carry secrets (API tokens,
+          // passwords) supplied by the script/generator, and scriptCommand
+          // embeds those values verbatim.
           console.log('='.repeat(80));
           console.log(`[SSH Execution] Executing on host: ${server.ip} (${server.name || 'Unnamed'})`);
           console.log(`[SSH Execution] Script path: ${scriptPath}`);
           console.log(`[SSH Execution] Relative script path: ${relativeScriptPath}`);
           if (Object.keys(envVars).length > 0) {
-            console.log(`[SSH Execution] Environment variables (${Object.keys(envVars).length} vars):`);
-            Object.entries(envVars).forEach(([key, value]) => {
-              console.log(`  ${key}=${String(value)}`);
-            });
+            console.log(`[SSH Execution] Environment variables (${Object.keys(envVars).length}): ${Object.keys(envVars).join(', ')} (values redacted)`);
           } else {
             console.log(`[SSH Execution] No environment variables provided`);
           }
-          console.log(`[SSH Execution] Full command:`);
-          console.log(scriptCommand);
           console.log('='.repeat(80));
 
           // Add the script execution command to the args

--- a/src/server/ssh-execution-service.js
+++ b/src/server/ssh-execution-service.js
@@ -295,9 +295,11 @@ class SSHExecutionService {
    * @param {Function} onData - Callback for data output
    * @param {Function} onError - Callback for errors
    * @param {Function} onExit - Callback for process exit
+   * @param {number} [cols] - Terminal columns (should match the browser's actual xterm size)
+   * @param {number} [rows] - Terminal rows (should match the browser's actual xterm size)
    * @returns {Promise<Object>} Process information
    */
-  async executeCommand(server, command, onData, onError, onExit) {
+  async executeCommand(server, command, onData, onError, onExit, cols = 120, rows = 30) {
     return new Promise((resolve, reject) => {
       try {
         // Build SSH command based on authentication type
@@ -309,8 +311,8 @@ class SSHExecutionService {
         // Use ptySpawn for proper terminal emulation and color support
         const sshCommand = ptySpawn(sshCommandName, args, {
           name: 'xterm-color',
-          cols: 120,
-          rows: 30,
+          cols,
+          rows,
           cwd: process.cwd(),
           env: process.env
         });


### PR DESCRIPTION
## Summary
- Fixed 4 GitHub issues: batch update confirm button stuck disabled, server credentials wiped on edit, installed-script records stuck "in_progress", uninformative script download errors
- Fixed PVE-type PocketBase scripts (e.g. "PVE LXC Execute") never being detected as downloaded despite successful download
- Batch "Update All" now runs minimized in the background and auto-advances on real script completion instead of requiring manual window close
- Security hardening: WebSocket start-message validation, path traversal guard, credential redaction on previously-unredacted server endpoints, secret values no longer logged, env-var key sanitization
- Fixed stuck "in_progress" installed-script records on manual stop / null-process races
- Update executions now persist final status/output to the DB (previously silent)
- Batch update completion summary (succeeded/failed per container)
- Removed overbroad regex fallbacks for container ID / web UI IP detection
- Root-caused and fixed whiptail/dialog centering: real terminal cols/rows are now threaded through every execution path instead of hardcoded small defaults
- Added a reusable toast notification system; wired into server add/edit/delete
- Consistent Esc-to-close + z-index handling across all modals
- Higher-contrast NEWT_COLORS for whiptail/dialog UIs
- Fixed a TypeScript 7 regression that broke the production build (reverted to ^6.0.3)
- Fixed PostCSS XSS advisory